### PR TITLE
ci: adapt libnode to buildchain v1

### DIFF
--- a/.github/actions/builder/action.yml
+++ b/.github/actions/builder/action.yml
@@ -1,10 +1,12 @@
+name: "Build libnode"
+description: "Build and package libnode prebuilt artifacts"
 runs:
   using: "composite"
   steps:
     - name: Setup Node.js environment
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v6.4.0
       with:
-        node-version: "14"
+        node-version: "22"
         registry-url: "https://npm.pkg.github.com"
         scope: "@kungfu-trader"
 
@@ -12,25 +14,27 @@ runs:
       env:
         KF_SKIP_FALLBACK_BUILD: true
       shell: bash
-      run: yarn --network-timeout=5000000 install --frozen-lockfile
+      run: |
+        corepack enable
+        corepack yarn --network-timeout=5000000 install --frozen-lockfile
 
     - name: Make libnode
       shell: bash
       # Workaround for gyp not able to find nasm.exe when run on GitHub Windows runner
-      run: yarn make
+      run: corepack yarn make
 
     - name: Build
       env:
         KF_SKIP_MAKE_LIBNODE: true
       shell: bash
-      run: yarn build
+      run: corepack yarn build
 
     - name: Package
       shell: bash
-      run: yarn package
+      run: corepack yarn package
 
     - name: Upload
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v6.0.0
       with:
         # https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#github-context
         name: "libnode-${{env.BUILDER_OS}}-${{github.actor}}-${{github.sha}}"

--- a/.github/actions/builder/action.yml
+++ b/.github/actions/builder/action.yml
@@ -13,12 +13,15 @@ runs:
     - name: Setup Yarn environment
       env:
         KF_SKIP_FALLBACK_BUILD: true
+        npm_config_link_node_binary_host_mirror: https://prebuilt.libkungfu.io
       shell: bash
       run: |
         corepack enable
         corepack yarn --network-timeout=5000000 install --frozen-lockfile
 
     - name: Make libnode
+      env:
+        npm_config_link_node_binary_host_mirror: https://prebuilt.libkungfu.io
       shell: bash
       # Workaround for gyp not able to find nasm.exe when run on GitHub Windows runner
       run: corepack yarn make
@@ -26,10 +29,13 @@ runs:
     - name: Build
       env:
         KF_SKIP_MAKE_LIBNODE: true
+        npm_config_link_node_binary_host_mirror: https://prebuilt.libkungfu.io
       shell: bash
       run: corepack yarn build
 
     - name: Package
+      env:
+        npm_config_link_node_binary_host_mirror: https://prebuilt.libkungfu.io
       shell: bash
       run: corepack yarn package
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,12 +12,12 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             name: "Linux"
             container: "docker.io/kungfutrader/kungfu-builder-centos:v1.1.2"
-          - os: macos-11
+          - os: macos-15
             name: "MacOS"
-          - os: windows-2019
+          - os: windows-2025
             name: "Windows"
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
@@ -26,26 +26,26 @@ jobs:
       BUILDER_OS: ${{ matrix.name }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7.0.0
         with:
           submodules: recursive
 
       - name: Setup Python environment
         if: matrix.name != 'Linux'
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: "3.9"
 
       - name: Setup Windows environment
         if: matrix.name == 'Windows'
-        uses: crazy-max/ghaction-chocolatey@v1
-        with:
-          args: install -y nasm --no-progress
+        shell: pwsh
+        run: choco install -y nasm --no-progress
 
       - name: Setup Windows PATH for nasm
         if: matrix.name == 'Windows'
+        shell: pwsh
         run: |
-          Get-ChildItem -Path "${env:ProgramFiles}" | Where-Object {($_.Name -Like 'NASM*')} | % { $_.FullName } | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+          Get-ChildItem -Path "${env:ProgramFiles}" | Where-Object { $_.Name -Like 'NASM*' } | ForEach-Object { $_.FullName } | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
       
       - name: Build
         uses: ./.github/actions/builder

--- a/.github/workflows/buildchain-preflight.yml
+++ b/.github/workflows/buildchain-preflight.yml
@@ -1,0 +1,31 @@
+name: Buildchain Preflight
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - dev/v*.x
+      - alpha/v*/v*.*
+      - release/v*/v*.*
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: buildchain-preflight-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate-config:
+    name: Validate buildchain.toml
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.0
+
+      - name: Validate Buildchain config
+        uses: kungfu-systems/buildchain/actions/validate-config@v1
+        with:
+          config-required: "true"
+          require-version-state: "true"
+          require-lifecycle-stages: "install,build,verify"

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -3,47 +3,47 @@ on:
   pull_request:
     types: [closed]
     branches:
-      - release/v*.x
+      - release/v*/v*.*
 
 jobs:
   publish-aws:
     if: ${{ github.event.pull_request.merged }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7.0.0
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v6.4.0
         with:
-          node-version: "14"
+          node-version: "22"
           registry-url: "https://npm.pkg.github.com"
           scope: "@kungfu-trader"
 
-      - name: Configure AWS Crendentials (US)
-        uses: aws-actions/configure-aws-credentials@v1
+      - name: Configure AWS Credentials (US)
+        uses: aws-actions/configure-aws-credentials@v6.2.1
         with:
           aws-access-key-id: ${{ secrets.AWS_US_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_US_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
 
       - name: Publish Prebuilt to AWS (US)
-        uses: kungfu-trader/action-publish-prebuilt@v2
+        uses: kungfu-systems/buildchain/actions/publish-prebuilt@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           bucket-staging: 'kungfu-prebuilt-staging'
           bucket-release: 'kungfu-prebuilt'
           no-comment: "true"
 
-      - name: Configure AWS Crendentials (CN)
-        uses: aws-actions/configure-aws-credentials@v1
+      - name: Configure AWS Credentials (CN)
+        uses: aws-actions/configure-aws-credentials@v6.2.1
         with:
           aws-access-key-id: ${{ secrets.AWS_CN_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_CN_SECRET_ACCESS_KEY }}
           aws-region: cn-northwest-1
 
       - name: Publish Prebuilt to AWS (CN)
-        uses: kungfu-trader/action-publish-prebuilt@v2
+        uses: kungfu-systems/buildchain/actions/publish-prebuilt@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           bucket-staging: 'kungfu-prebuilt-staging'
@@ -51,15 +51,15 @@ jobs:
 
   publish-github:
     if: ${{ github.event.pull_request.merged }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7.0.0
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v6.4.0
         with:
-          node-version: "14"
+          node-version: "22"
           registry-url: "https://npm.pkg.github.com"
           scope: "@kungfu-trader"
 
@@ -70,15 +70,15 @@ jobs:
   
   publish-npmjs:
     if: ${{ github.event.pull_request.merged }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7.0.0
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v6.4.0
         with:
-          node-version: "14"
+          node-version: "22"
           registry-url: 'https://registry.npmjs.org'
 
       - name: Publish to NPM Packages

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -1,89 +1,88 @@
 name: Release - Verify
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, reopened]
     branches:
-      - release/v*.x
+      - alpha/v*/v*.*
+      - release/v*/v*.*
 
 jobs:
   build:
     strategy:
       matrix:
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             name: "Linux"
-            container: "docker.io/kungfutrader/kungfu-builder-centos:v1.1.2"
-          - os: macos-11
+          - os: macos-15
             name: "MacOS"
-          - os: windows-2019
+          - os: windows-2025
             name: "Windows"
     runs-on: ${{ matrix.os }}
-    container: ${{ matrix.container }}
     env:
       USE_HARD_LINKS: false
       BUILDER_OS: ${{ matrix.name }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7.0.0
         with:
           submodules: recursive
 
       - name: Setup Python environment
-        if: matrix.name != 'Linux'
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: "3.9"
 
       - name: Setup Windows environment
         if: matrix.name == 'Windows'
-        uses: crazy-max/ghaction-chocolatey@v1
-        with:
-          args: install -y nasm --no-progress
+        shell: pwsh
+        run: choco install -y nasm --no-progress
 
       - name: Setup Windows PATH for nasm
         if: matrix.name == 'Windows'
+        shell: pwsh
         run: |
-          Get-ChildItem -Path "${env:ProgramFiles}" | Where-Object {($_.Name -Like 'NASM*')} | % { $_.FullName } | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
-      
+          Get-ChildItem -Path "${env:ProgramFiles}" | Where-Object { $_.Name -Like 'NASM*' } | ForEach-Object { $_.FullName } | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+
       - name: Build
         uses: ./.github/actions/builder
 
   release:
+    if: startsWith(github.base_ref, 'release/')
     needs: [build]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7.0.0
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v6.0.0
         with:
           path: "github-artifacts"
 
-      - name: Configure AWS Crendentials (US)
-        uses: aws-actions/configure-aws-credentials@v1
+      - name: Configure AWS Credentials (US)
+        uses: aws-actions/configure-aws-credentials@v6.2.1
         with:
           aws-access-key-id: ${{ secrets.AWS_US_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_US_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
 
       - name: Stage Prebuilt to AWS (US)
-        uses: kungfu-trader/action-publish-prebuilt@v2
+        uses: kungfu-systems/buildchain/actions/publish-prebuilt@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           artifacts-path: "github-artifacts"
           bucket-staging: "kungfu-prebuilt-staging"
           no-comment: "true"
 
-      - name: Configure AWS Crendentials (CN)
-        uses: aws-actions/configure-aws-credentials@v1
+      - name: Configure AWS Credentials (CN)
+        uses: aws-actions/configure-aws-credentials@v6.2.1
         with:
           aws-access-key-id: ${{ secrets.AWS_CN_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_CN_SECRET_ACCESS_KEY }}
           aws-region: cn-northwest-1
 
       - name: Stage Prebuilt to AWS (CN)
-        uses: kungfu-trader/action-publish-prebuilt@v2
+        uses: kungfu-systems/buildchain/actions/publish-prebuilt@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           artifacts-path: "github-artifacts"

--- a/.gyp/node-npm-config.js
+++ b/.gyp/node-npm-config.js
@@ -5,41 +5,34 @@ const path = require('path');
 const { spawnSync } = require('child_process');
 
 const PrebuiltHostConfig = 'binary_host_mirror';
-const PrebuiltHost_US = 'https://prebuilt.libkungfu.io';
 
-const spawnOptsPipe = { shell: true, stdio: 'pipe', windowsHide: true };
-const spawnOptsInherit = { shell: true, stdio: 'inherit', windowsHide: true };
+const spawnOptsPipe = { stdio: 'pipe', windowsHide: true };
 
 const packageJson = JSON.parse(fs.readFileSync(path.resolve(path.dirname(__dirname), 'package.json')));
 const key = packageJson.binary.module_name;
 const npmConfigKey = `${key}_${PrebuiltHostConfig}`;
+const npmConfigEnvKey = `npm_config_${npmConfigKey}`;
 
-const scope = (npmConfigValue) => (npmConfigValue === 'undefined' ? '[package.json]' : '[user]');
-
-function npmCall(npmArgs) {
-  console.log(`$ npm ${npmArgs.join(' ')}`);
-  const result = spawnSync('npm', npmArgs, spawnOptsInherit);
-  if (result.status !== 0) {
-    console.error(`Failed with status ${status}`);
-    process.exit(result.status);
-  }
-}
+const scope = (source) => `[${source}]`;
 
 function getNpmConfigValue(key) {
-  return spawnSync('npm', ['config', 'get', key], spawnOptsPipe)
-    .output.filter((e) => e && e.length > 0)
+  const result = spawnSync('npm', ['config', 'get', key], spawnOptsPipe);
+  if (result.status !== 0) {
+    return undefined;
+  }
+  return result.output
+    .filter((e) => e && e.length > 0)
     .toString()
     .trimEnd();
 }
 
 function showAllConfig() {
-  const hostConfigValue = getNpmConfigValue(npmConfigKey);
-  const value = hostConfigValue === 'undefined' && packageJson ? packageJson.binary.host : hostConfigValue;
-  console.log(`[binary] ${npmConfigKey} = ${value} ${scope(hostConfigValue)}`);
-}
-
-if (require.main === module && process.env.CI && process.env.GITHUB_ACTIONS) {
-  npmCall(['config', 'set', npmConfigKey, PrebuiltHost_US]);
+  const envConfigValue = process.env[npmConfigEnvKey] || process.env[npmConfigEnvKey.toUpperCase()];
+  const userConfigValue = getNpmConfigValue(npmConfigKey);
+  const hasUserConfig = userConfigValue && userConfigValue !== 'undefined';
+  const value = envConfigValue || (hasUserConfig ? userConfigValue : packageJson.binary.host);
+  const source = envConfigValue ? 'env' : hasUserConfig ? 'user' : 'package.json';
+  console.log(`[binary] ${npmConfigKey} = ${value} ${scope(source)}`);
 }
 
 if (require.main === module) {

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Install via npm/yarn:
 npm install @kungfu-trader/libnode
 ```
 
-Be default it downloads prebuilt lib files from a site host by [AWS CN](https://prebuilt.libkungfu.cc).
-If need to use it overseas, use npm config to set it to AWS US before npm install:
+By default it downloads prebuilt lib files from a site host by [AWS CN](https://prebuilt.libkungfu.cc).
+If need to use it overseas, set the node-pre-gyp mirror environment variable before npm install:
 ```
-npm config set link_node_binary_host_mirror https://prebuilt.libkungfu.io
+npm_config_link_node_binary_host_mirror=https://prebuilt.libkungfu.io npm install @kungfu-trader/libnode
 ```
 
 ### Compile and Link

--- a/README.md
+++ b/README.md
@@ -29,4 +29,11 @@ node -p "require('@kungfu-trader/libnode').include"
 
 ## Build with GitHub Actions
 
-If you need other versions of Node.js that we don't provide, you can fork [this repo on GitHub](https://github.com/kungfu-trader/libnode) and build with GitHub Actions. There is a workflow named "Build" that can be triggered mannually with an input argument, type the git tag of [node](https://github.com/nodejs/node) that you want to use and go. The result will be uploaded to GitHub Actions when successfully finished.
+If you need other versions of Node.js that we don't provide, you can fork [this repo on GitHub](https://github.com/kungfu-systems/libnode) and build with GitHub Actions. There is a workflow named "Build" that can be triggered manually with an input argument, type the git tag of [node](https://github.com/nodejs/node) that you want to use and go. The result will be uploaded to GitHub Actions when successfully finished.
+
+## Buildchain
+
+This repository uses Buildchain v1 shared actions and declares its local release
+lifecycle in [`buildchain.toml`](buildchain.toml). See
+[`docs/buildchain.md`](docs/buildchain.md) for the libnode-specific release
+notes.

--- a/buildchain.toml
+++ b/buildchain.toml
@@ -1,0 +1,35 @@
+schema = 1
+
+[version]
+required = true
+
+[[version.files]]
+type = "json"
+path = "package.json"
+key = "version"
+
+[lifecycle.env]
+KF_SKIP_FALLBACK_BUILD = "true"
+
+[lifecycle.install]
+timeout_minutes = 10
+command = "corepack yarn --network-timeout=5000000 install --frozen-lockfile"
+
+[lifecycle.build]
+timeout_minutes = 120
+commands = [
+  "corepack yarn make",
+  "KF_SKIP_MAKE_LIBNODE=true corepack yarn build",
+  "corepack yarn package",
+]
+
+[lifecycle.verify]
+timeout_minutes = 120
+script = """
+set -euo pipefail
+corepack yarn --network-timeout=5000000 install --frozen-lockfile
+corepack yarn make
+KF_SKIP_MAKE_LIBNODE=true corepack yarn build
+corepack yarn package
+git diff --check
+"""

--- a/docs/buildchain.md
+++ b/docs/buildchain.md
@@ -29,6 +29,24 @@ The workflow invokes Yarn through Corepack so the runner follows
 `packageManager` in `package.json` instead of relying on a preinstalled global
 Yarn binary.
 
+## No-build Preflight
+
+The migration can be validated before running the expensive native build. The
+Buildchain v1 `validate-config` action checks that `buildchain.toml` is present,
+that `package.json#version` is readable as version state, and that the required
+`install`, `build`, and `verify` lifecycle stages are declared.
+
+That preflight is intentionally structural. It does not run
+`corepack yarn make`, `corepack yarn build`, or `corepack yarn package`.
+
+The local preflight result for this adaptation is:
+
+```text
+configPath: buildchain.toml
+versionFiles: package.json
+lifecycleStages: install, build, verify
+```
+
 ## Release Workflow
 
 Release verification still builds platform artifacts in this repository because

--- a/docs/buildchain.md
+++ b/docs/buildchain.md
@@ -32,12 +32,25 @@ Yarn binary.
 ## No-build Preflight
 
 The migration can be validated before running the expensive native build. The
-Buildchain v1 `validate-config` action checks that `buildchain.toml` is present,
-that `package.json#version` is readable as version state, and that the required
-`install`, `build`, and `verify` lifecycle stages are declared.
+published Buildchain v1 `validate-config` action checks that
+`buildchain.toml` is present, that `package.json#version` is readable as version
+state, and that the required `install`, `build`, and `verify` lifecycle stages
+are declared.
 
 That preflight is intentionally structural. It does not run
 `corepack yarn make`, `corepack yarn build`, or `corepack yarn package`.
+
+The repository runs this check through
+`.github/workflows/buildchain-preflight.yml` on PRs into the development, alpha,
+and release lines:
+
+```yaml
+uses: kungfu-systems/buildchain/actions/validate-config@v1
+with:
+  config-required: "true"
+  require-version-state: "true"
+  require-lifecycle-stages: "install,build,verify"
+```
 
 The local preflight result for this adaptation is:
 

--- a/docs/buildchain.md
+++ b/docs/buildchain.md
@@ -1,0 +1,39 @@
+# Buildchain Release Notes
+
+`libnode` uses Buildchain v1 for shared Kungfu GitHub Actions and for
+repository-local lifecycle metadata.
+
+## Version State
+
+`buildchain.toml` declares `package.json#version` as the release version state.
+For this repository the package version follows the upstream Node.js version
+that the embedded `node` submodule builds, for example `22.22.3`.
+
+The package name remains `@kungfu-trader/libnode` because downstream Kungfu
+projects already consume that package scope.
+
+## Lifecycle
+
+The configured lifecycle keeps the existing libnode build order:
+
+1. install JavaScript build helpers with Yarn;
+2. build the embedded Node.js shared library;
+3. build the `link_node` addon;
+4. package the node-pre-gyp prebuilt archive;
+5. check the final diff.
+
+The full lifecycle is intentionally expensive. Release PRs should rely on the
+GitHub matrix workflow for Linux, macOS, and Windows verification.
+
+The workflow invokes Yarn through Corepack so the runner follows
+`packageManager` in `package.json` instead of relying on a preinstalled global
+Yarn binary.
+
+## Release Workflow
+
+Release verification still builds platform artifacts in this repository because
+libnode has platform-specific native outputs. Shared Buildchain v1 actions are
+used for reusable release steps such as publishing prebuilt artifacts.
+
+Production publishing remains gated by a reviewed PR into the release channel
+and by successful artifact staging.

--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
   "description": "Build shared node lib",
   "license": "Apache-2.0",
   "main": "src/js/index.js",
+  "packageManager": "yarn@1.22.22",
   "repository": {
-    "url": "https://github.com/kungfu-trader/libnode.git"
+    "url": "https://github.com/kungfu-systems/libnode.git"
   },
   "binary": {
     "module_name": "link_node",

--- a/yarn.lock
+++ b/yarn.lock
@@ -766,7 +766,7 @@ safe-buffer@~5.2.0:
 
 sax@^1.2.4:
   version "1.2.4"
-  resolved "https://registry.nlark.com/sax/download/sax-1.2.4.tgz"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz"
   integrity sha1-KBYjTiN4vdxOU1T6tcqold9xANk=
 
 semver@^6.0.0:


### PR DESCRIPTION
## Summary
- add buildchain.toml lifecycle metadata for libnode
- move release workflows to buildchain v1 shared actions and current GitHub Actions runners/actions
- document the libnode buildchain release protocol

## Validation
- actionlint .github/workflows/*.yml
- parsed buildchain.toml with buildchain smol-toml dependency
- loaded buildchain.toml through buildchain packages/core buildchain-config loader
- corepack yarn --network-timeout=5000000 install --frozen-lockfile --ignore-scripts
- node -e "const pkg=require('./package.json'); const lib=require('./src/js'); console.log(pkg.version, Object.keys(lib).sort().join(','));"
- git diff --check HEAD~1 HEAD

## Notes
Full native prebuilt build is intentionally left to GitHub self-hosted/hosted runners because libnode builds are platform-sensitive and heavyweight.