### PR TITLE
release: promote libnode 22.22.3-kf.2 to alpha

### DIFF
--- a/.github/workflows/buildchain-preflight.yml
+++ b/.github/workflows/buildchain-preflight.yml
@@ -29,4 +29,4 @@ jobs:
         with:
           config-required: 'true'
           require-version-state: 'true'
-          require-lifecycle-stages: 'install,build,verify'
+          require-lifecycle-stages: 'install,build,verify,publish'

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -117,5 +117,6 @@ jobs:
           allow-repository: ${{ github.repository }}
           require-governance: 'true'
           require-version-state: 'true'
+          required-status-check: 'build'
           publish-transaction: 'true'
           publish-required-artifacts-json: ${{ steps.evidence.outputs.required-artifacts-json }}

--- a/libnode.release.json
+++ b/libnode.release.json
@@ -3,6 +3,6 @@
   "nodeVersion": "22.22.3",
   "nodeTag": "v22.22.3",
   "nodeCommit": "fdfa0ff0dbaf0fbf4d7d6d89a2ab807f3177fa5c",
-  "libnodeRevision": 1,
-  "npmVersion": "22.22.3-kf.1"
+  "libnodeRevision": 2,
+  "npmVersion": "22.22.3-kf.2"
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "name": "kungfu-trader",
     "email": "info@kungfu.link"
   },
-  "version": "22.22.3-kf.1",
+  "version": "22.22.3-kf.2",
   "description": "Build shared node lib",
   "license": "Apache-2.0",
   "main": "src/js/index.js",


### PR DESCRIPTION
Promote libnode 22.22.3-kf.2 through the Buildchain alpha channel.\n\n- Uses stable buildchain @v2 transaction publishing\n- Includes darwin/linux alias packaging fix\n- Includes Windows .dll/.lib/header package gates\n- Version state: package.json and libnode.release.json = 22.22.3-kf.2