### PR TITLE
fix: prevent default node-gyp install during publish

### DIFF
--- a/.gyp/node-platform-package.js
+++ b/.gyp/node-platform-package.js
@@ -363,10 +363,14 @@ async function verifySource() {
     throw new Error('package.json must not depend on @mapbox/node-pre-gyp');
   }
 
-  for (const scriptName of ['preinstall', 'install', 'prebuild']) {
+  for (const scriptName of ['preinstall', 'prebuild']) {
     if (scripts[scriptName]) {
       throw new Error(`package.json must not define ${scriptName}`);
     }
+  }
+
+  if (scripts.install !== 'node .gyp/noop-install.js') {
+    throw new Error('package.json install script must be the libnode no-op install guard');
   }
 
   for (const descriptor of platformPackages) {

--- a/.gyp/noop-install.js
+++ b/.gyp/noop-install.js
@@ -1,0 +1,1 @@
+console.log('libnode install uses platform packages; skipping source tree node-gyp rebuild');

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "README.md"
   ],
   "scripts": {
+    "install": "node .gyp/noop-install.js",
     "build": "node .gyp/node-build.js build",
     "clean": "node .gyp/node-build.js clean",
     "dist": "node .gyp/node-dist.js",


### PR DESCRIPTION
## Summary\n- add a no-op install guard so publish verification does not trigger package-manager default node-gyp rebuild from binding.gyp\n- keep source package gate strict by allowing only the fixed no-op install script\n\n## Verification\n- corepack pnpm verify-package-source\n- corepack pnpm verify-release\n- git diff --check