### PR TITLE
fix: build libnode through node-gyp dependency graph

### DIFF
--- a/.gyp/node-build.js
+++ b/.gyp/node-build.js
@@ -1,6 +1,7 @@
 const fs = require('fs-extra');
 const path = require('path');
 const sywac = require('sywac');
+const { prepareWindowsPythonEnv } = require('./build-env.js');
 const { exitOnError, run } = require('./node-lib.js');
 
 const rootDir = path.dirname(__dirname);
@@ -8,6 +9,7 @@ const nodeGyp = require.resolve('node-gyp/bin/node-gyp.js');
 const addonModuleName = 'link_node';
 
 function runNodeGyp(args) {
+  prepareWindowsPythonEnv(process.env);
   run(process.execPath, [nodeGyp, `--module_name=${addonModuleName}`, ...args], {
     cwd: rootDir,
     env: process.env,

--- a/.gyp/node-build.js
+++ b/.gyp/node-build.js
@@ -18,10 +18,6 @@ function runNodeGyp(args) {
 
 async function build() {
   runNodeGyp(['configure', 'build']);
-  run(process.execPath, ['.gyp/node-dist.js'], {
-    cwd: rootDir,
-    env: process.env,
-  });
 }
 
 async function clean() {

--- a/.gyp/node-dist.js
+++ b/.gyp/node-dist.js
@@ -4,8 +4,10 @@ const { globSync } = require('glob');
 const path = require('path');
 const sywac = require('sywac');
 
+const rootDir = path.dirname(__dirname);
+
 const dist = (buildType) => {
-  const nodeDistDir = path.join('dist', 'node');
+  const nodeDistDir = path.join(rootDir, 'dist', 'node');
   const exts = ['.json', '.node', '.dylib', '.so', '.dll', '.lib'];
 
   const globFiles = (pattern) =>
@@ -34,13 +36,13 @@ const dist = (buildType) => {
   fse.ensureDirSync(nodeDistDir);
   fse.emptyDirSync(nodeDistDir);
 
-  copyFiles(path.join('build', buildType, '*.*'));
-  copyFiles(path.join('node', buildType, 'libnode*'));
-  copyFiles(path.join('node', 'out', buildType, 'libnode*'));
+  copyFiles(path.join(rootDir, 'build', buildType, '*.*'));
+  copyFiles(path.join(rootDir, 'node', buildType, 'libnode*'));
+  copyFiles(path.join(rootDir, 'node', 'out', buildType, 'libnode*'));
 
-  copyHeaders(path.resolve('node', 'src'));
-  copyHeaders(path.resolve('node', 'deps', 'v8', 'include'));
-  copyHeaders(path.resolve('node', 'deps', 'uv', 'include'));
+  copyHeaders(path.join(rootDir, 'node', 'src'));
+  copyHeaders(path.join(rootDir, 'node', 'deps', 'v8', 'include'));
+  copyHeaders(path.join(rootDir, 'node', 'deps', 'uv', 'include'));
 
   makeSymbolLink('libnode.*.dylib', 'dylib');
   makeSymbolLink('libnode.so.*', 'so');

--- a/.gyp/node-make.js
+++ b/.gyp/node-make.js
@@ -8,8 +8,9 @@ const sywac = require('sywac');
 const convert = require('xml-js');
 
 const arch = process.arch;
-const nodeSrcDir = path.resolve('node');
-const nodeDistDir = path.join(path.dirname(__dirname), 'dist', 'node');
+const rootDir = path.dirname(__dirname);
+const nodeSrcDir = path.join(rootDir, 'node');
+const nodeDistDir = path.join(rootDir, 'dist', 'node');
 
 function flag(name) {
   return /^(1|true|yes|on)$/i.test(process.env[name] || '');
@@ -191,7 +192,7 @@ const stamp = (buildType) => {
     .filter((e) => e && e.length > 0)
     .toString()
     .trim();
-  const packageJson = JSON.parse(fs.readFileSync('package.json'));
+  const packageJson = JSON.parse(fs.readFileSync(path.join(rootDir, 'package.json')));
   const userInfo = os.userInfo();
   const buildInfo = {
     version: packageJson.version,
@@ -203,7 +204,7 @@ const stamp = (buildType) => {
       timestamp: new Date(),
     },
   };
-  const targetDir = path.join('build', buildType);
+  const targetDir = path.join(rootDir, 'build', buildType);
   fse.ensureDirSync(targetDir);
   const buildInfoFile = path.join(targetDir, 'libnodebuildinfo.json');
   fs.writeFileSync(buildInfoFile, JSON.stringify(buildInfo, null, 2));

--- a/.gyp/node-make.js
+++ b/.gyp/node-make.js
@@ -179,7 +179,7 @@ const buildWin = () => {
 const buildUnix = () => {
   cleanNodeBuildState();
   prepareCompilerCache();
-  run('sh', [path.join('.', 'configure'), '-C', '--shared'], { cwd: nodeSrcDir });
+  run('sh', [path.join('.', 'configure'), '--shared'], { cwd: nodeSrcDir });
   run('make', ['-j', `${buildJobs()}`], { cwd: nodeSrcDir });
   showCompilerCacheStats();
 };

--- a/buildchain.toml
+++ b/buildchain.toml
@@ -27,8 +27,7 @@ commands = [
 [lifecycle.build]
 timeout_minutes = 240
 commands = [
-  "corepack pnpm make",
-  "node .gyp/run-with-env.js KF_SKIP_MAKE_LIBNODE=true -- corepack pnpm build",
+  "corepack pnpm build",
   "corepack pnpm package",
 ]
 

--- a/docs/buildchain.md
+++ b/docs/buildchain.md
@@ -26,13 +26,13 @@ publishing to the official npm registry.
 
 ## Lifecycle
 
-The configured lifecycle keeps the existing libnode build order:
+The configured lifecycle keeps the existing libnode build dependency order:
 
 1. install JavaScript build helpers with pnpm;
-2. build the embedded Node.js shared library;
-3. build the `link_node` addon;
-4. package the platform-specific npm tarball under `build/stage/npm`;
-5. check the final diff.
+2. run the node-gyp build graph, whose `libnode` target builds the embedded
+   Node.js shared library before the `link_node` addon and dist target;
+3. package the platform-specific npm tarball under `build/stage/npm`;
+4. check the final diff.
 
 The full lifecycle is intentionally expensive. Release PRs should rely on the
 GitHub matrix workflow for Linux, macOS arm64, and Windows verification.


### PR DESCRIPTION
## Summary\n- run the libnode build through the node-gyp dependency graph so the libnode target produces platform binaries before packaging\n- remove the split make + KF_SKIP_MAKE_LIBNODE build sequence that could leave dist without libnode.so on release push runners\n\n## Verification\n- python3 tomllib parse of buildchain.toml\n- corepack pnpm verify-package-source\n- corepack pnpm verify-release\n- git diff --check