### PR TITLE
fix: ignore buildchain publish artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,7 @@ __pypackages__/
 
 # Build related
 .buildchain/
+github-artifacts/
 build/
 build-*/
 cmake-build-debug/


### PR DESCRIPTION
Allow Buildchain publish jobs to download GitHub artifact evidence under github-artifacts/ without tripping version-state cleanliness checks.