### PR TITLE
release: publish libnode 22.22.3-kf.3-alpha.0

### DIFF
--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -109,7 +109,6 @@ jobs:
         env:
           KF_NPM_DIST_TAG: ${{ needs.build.outputs.publish-channel == 'alpha' && 'alpha' || 'latest' }}
           KF_NPM_EXPECTED_VERSION: ${{ fromJSON(needs.build.outputs.release-manifest-json).anchorManifest.summary.npmVersion }}
-          KF_NPM_RELEASE_REQUIRES_EXISTING: 'true'
         with:
           token: ${{ secrets.BUILDCHAIN_PROMOTION_TOKEN || github.token }}
           sha: ${{ needs.build.outputs.publish-source-sha }}
@@ -119,4 +118,9 @@ jobs:
           require-version-state: 'true'
           required-status-check: 'build'
           publish-transaction: 'true'
+          publish-mode: publish-final-version
+          publish-auth: trusted-publishing
+          publish-dist-tag: ${{ needs.build.outputs.publish-channel == 'alpha' && 'alpha' || 'latest' }}
+          publish-package-set-order: platforms-first-main-last
+          publish-package-main: '@kungfu-tech/libnode'
           publish-required-artifacts-json: ${{ steps.evidence.outputs.required-artifacts-json }}

--- a/.gyp/libnode-release-verify.js
+++ b/.gyp/libnode-release-verify.js
@@ -50,7 +50,13 @@ function verifyReleaseManifest() {
   if (!Number.isInteger(release.libnodeRevision) || release.libnodeRevision < 0) {
     fail('libnodeRevision must be a non-negative integer');
   }
-  assertEqual(release.npmVersion, `${release.nodeVersion}-kf.${release.libnodeRevision}`, 'npmVersion');
+  const stableNpmVersion = `${release.nodeVersion}-kf.${release.libnodeRevision}`;
+  if (
+    release.npmVersion !== stableNpmVersion &&
+    !new RegExp(`^${stableNpmVersion}-alpha\\.\\d+$`).test(release.npmVersion)
+  ) {
+    fail(`npmVersion must be ${stableNpmVersion} or ${stableNpmVersion}-alpha.N`);
+  }
 }
 
 function verifyPackageVersion() {

--- a/.gyp/npm-publish-tarballs.js
+++ b/.gyp/npm-publish-tarballs.js
@@ -141,6 +141,7 @@ function buildchainArtifact(pkg) {
     name: pkg.name,
     ref: pkg.version,
     digest: pkg.integrity,
+    role: isMainPackage(pkg) ? 'main' : 'platform',
     required: true,
   };
 }
@@ -220,9 +221,8 @@ function verifyExistingPackage(pkg, existingIntegrity) {
   return true;
 }
 
-function releaseRequiresExisting(distTag) {
-  if (distTag !== 'latest') return false;
-  return process.env.KF_NPM_RELEASE_REQUIRES_EXISTING !== 'false';
+function publishMode() {
+  return process.env.BUILDCHAIN_PUBLISH_MODE || 'publish-final-version';
 }
 
 function publishTarball(pkg, distTag) {
@@ -306,7 +306,11 @@ async function main() {
     return;
   }
 
-  const distTag = process.env.KF_NPM_DIST_TAG || 'latest';
+  const distTag = process.env.BUILDCHAIN_NPM_DIST_TAG || process.env.KF_NPM_DIST_TAG || 'latest';
+  const mode = publishMode();
+  if (!['publish-final-version', 'promote-existing-version'].includes(mode)) {
+    throw new Error(`Unsupported Buildchain publish mode: ${mode}`);
+  }
   const existing = new Set();
 
   for (const pkg of packages) {
@@ -316,15 +320,15 @@ async function main() {
       continue;
     }
 
-    if (releaseRequiresExisting(distTag)) {
-      throw new Error(`Release publish requires existing alpha package before latest promotion: ${packageKey(pkg)}`);
+    if (mode === 'promote-existing-version') {
+      throw new Error(`Existing-version promotion requires registry package before dist-tag move: ${packageKey(pkg)}`);
     }
 
     publishTarball(pkg, distTag);
   }
 
-  for (const pkg of packages) {
-    if (existing.has(packageKey(pkg)) || distTag === 'latest') {
+  if (mode === 'promote-existing-version') {
+    for (const pkg of packages) {
       addDistTag(pkg, distTag);
     }
   }

--- a/README.md
+++ b/README.md
@@ -34,13 +34,14 @@ The `Build` and `Release - Verify` workflows run through Kungfu Buildchain and b
 
 Npm publication is handled only by Buildchain channel promotion. A reviewed
 merge into `alpha/vN/vN.M` publishes the package set with dist-tag `alpha`; a
-reviewed merge into `release/vN/vN.M` promotes the already-published package set
-to dist-tag `latest`. The exact npm version is read from `package.json` and
+reviewed merge into `release/vN/vN.M` publishes the final package set with
+dist-tag `latest`. The exact npm version is read from `package.json` and
 `libnode.release.json`, not from the branch name.
 
 npm publication uses GitHub Trusted Publishing from the GitHub-hosted publish
-job. The workflow does not use `NPM_PUSH_TOKEN`; package access is authorized by
-the trusted publisher records on npm for this repository and workflow file.
+job. The workflow does not use `NPM_PUSH_TOKEN` or npm dist-tag recovery tokens
+for the normal path; package access is authorized by the trusted publisher
+records on npm for this repository and workflow file.
 
 For self-hosted runners, set `KF_NODE_GIT_URL` to a local network Git service when available. `KF_NODE_REFERENCE` can also point at a runner-local bare mirror to reduce repeated object transfer. If those variables are not set, the prepare step falls back to the public Node.js GitHub repository.
 

--- a/buildchain.toml
+++ b/buildchain.toml
@@ -11,6 +11,12 @@ type = "json"
 path = "package.json"
 key = "version"
 
+[publish]
+mode = "publish-final-version"
+auth = "trusted-publishing"
+package_set_order = "platforms-first-main-last"
+main_package = "@kungfu-tech/libnode"
+
 [lifecycle]
 
 [lifecycle.env]

--- a/docs/buildchain.md
+++ b/docs/buildchain.md
@@ -87,8 +87,8 @@ publish job, and npm is the release distribution surface.
 
 Actual npm publication is driven by reviewed Buildchain channel promotion, not
 by ad hoc publish branches. A merge into `alpha/vN/vN.M` publishes the package
-set with npm dist-tag `alpha`. A merge into `release/vN/vN.M` promotes the same
-package version to npm dist-tag `latest`.
+set with npm dist-tag `alpha`. A merge into `release/vN/vN.M` publishes the
+final package set with npm dist-tag `latest`.
 
 ```text
 alpha/v22/v22.22
@@ -106,13 +106,14 @@ Before touching npm, the publish job verifies that `package.json#version` and
 selects the Buildchain release line; it does not carry or override the package
 version.
 
-Alpha publication uses npm dist-tag `alpha`. Release publication uses dist-tag
-`latest`, but defaults to npm registry verification semantics: every package
-tarball must already exist in the registry with matching integrity, normally
-from the alpha run, and then `latest` is moved only after the full package set
-is verified.
+Alpha publication uses npm dist-tag `alpha` and should use an npm prerelease
+version such as `22.22.3-kf.3-alpha.0`. Release publication uses dist-tag
+`latest` and should use the corresponding final npm version such as
+`22.22.3-kf.3`. Both paths use `publish-final-version` through Buildchain and
+GitHub Trusted Publishing; same-version alpha-to-latest dist-tag promotion is a
+manual recovery mode, not the normal release path.
 
-The npm package set is published or retagged in platform-first/main-last order.
+The npm package set is published in platform-first/main-last order.
 The main `@kungfu-tech/libnode` package is the last visible package so npm
 optional dependency resolution can see the platform packages immediately.
 

--- a/libnode.release.json
+++ b/libnode.release.json
@@ -3,6 +3,6 @@
   "nodeVersion": "22.22.3",
   "nodeTag": "v22.22.3",
   "nodeCommit": "fdfa0ff0dbaf0fbf4d7d6d89a2ab807f3177fa5c",
-  "libnodeRevision": 2,
-  "npmVersion": "22.22.3-kf.2"
+  "libnodeRevision": 3,
+  "npmVersion": "22.22.3-kf.3-alpha.0"
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "name": "kungfu-trader",
     "email": "info@kungfu.link"
   },
-  "version": "22.22.3-kf.2",
+  "version": "22.22.3-kf.3-alpha.0",
   "description": "Build shared node lib",
   "license": "Apache-2.0",
   "main": "src/js/index.js",


### PR DESCRIPTION
## Summary
- promote dev/v22/v22.22 to alpha/v22/v22.22
- publish libnode package set version 22.22.3-kf.3-alpha.0 with npm dist-tag alpha
- exercise Buildchain publish-final-version + trusted-publishing release path

## Expected Buildchain behavior
- build Linux x64, macOS ARM64, and Windows x64 platform packages
- publish platform packages before @kungfu-tech/libnode
- use npm Trusted Publishing, not npm token-backed dist-tag promotion