### PR TITLE
ci: declare libnode release manifest version state

### DIFF
--- a/buildchain.toml
+++ b/buildchain.toml
@@ -11,6 +11,11 @@ type = "json"
 path = "package.json"
 key = "version"
 
+[[version.files]]
+type = "json"
+path = "libnode.release.json"
+key = "npmVersion"
+
 [publish]
 mode = "publish-final-version"
 auth = "trusted-publishing"

--- a/libnode.release.json
+++ b/libnode.release.json
@@ -4,5 +4,5 @@
   "nodeTag": "v22.22.3",
   "nodeCommit": "fdfa0ff0dbaf0fbf4d7d6d89a2ab807f3177fa5c",
   "libnodeRevision": 3,
-  "npmVersion": "22.22.3-kf.3-alpha.0"
+  "npmVersion": "22.22.3-kf.3-alpha.1"
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "name": "kungfu-trader",
     "email": "info@kungfu.link"
   },
-  "version": "22.22.3-kf.3-alpha.0",
+  "version": "22.22.3-kf.3-alpha.1",
   "description": "Build shared node lib",
   "license": "Apache-2.0",
   "main": "src/js/index.js",


### PR DESCRIPTION
## Summary
- declare libnode.release.json#npmVersion as a Buildchain version-state file
- advance the alpha package version to 22.22.3-kf.3-alpha.1 so release final can differ from alpha only by version-state files

## Why
Buildchain rejected the final release because release source differed from v22.22.0-alpha.1 in libnode.release.json, while only package.json was declared as version state.

## Validation
- corepack pnpm verify-release
- git diff --check
- node /Users/dkr/Code/kungfu-systems/buildchain/bin/buildchain.mjs validate --require-version-state