### PR TITLE
release: publish libnode 22.22.3-kf.3-alpha.1

### DIFF
--- a/buildchain.toml
+++ b/buildchain.toml
@@ -11,6 +11,11 @@ type = "json"
 path = "package.json"
 key = "version"
 
+[[version.files]]
+type = "json"
+path = "libnode.release.json"
+key = "npmVersion"
+
 [publish]
 mode = "publish-final-version"
 auth = "trusted-publishing"

--- a/libnode.release.json
+++ b/libnode.release.json
@@ -4,5 +4,5 @@
   "nodeTag": "v22.22.3",
   "nodeCommit": "fdfa0ff0dbaf0fbf4d7d6d89a2ab807f3177fa5c",
   "libnodeRevision": 3,
-  "npmVersion": "22.22.3-kf.3-alpha.0"
+  "npmVersion": "22.22.3-kf.3-alpha.1"
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "name": "kungfu-trader",
     "email": "info@kungfu.link"
   },
-  "version": "22.22.3-kf.3-alpha.0",
+  "version": "22.22.3-kf.3-alpha.1",
   "description": "Build shared node lib",
   "license": "Apache-2.0",
   "main": "src/js/index.js",


### PR DESCRIPTION
## Summary
- promote the version-state manifest fix from dev to alpha
- publish alpha package set 22.22.3-kf.3-alpha.1 as the release baseline

## Why
The final release gate requires release source to differ from the latest alpha source only by declared version-state files. This alpha establishes libnode.release.json#npmVersion as declared version state before retrying final release.

## Expected result
Merging into alpha/v22/v22.22 should run Release - New Version and publish the package set with npm dist-tag alpha.