### PR TITLE
ci(buildchain): add libnode build diagnostics

### DIFF
--- a/.gyp/buildchain-diagnostics.js
+++ b/.gyp/buildchain-diagnostics.js
@@ -1,0 +1,457 @@
+const childProcess = require('child_process');
+const crypto = require('crypto');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const rootDir = path.resolve(__dirname, '..');
+const diagnosticsRoot = path.join(rootDir, 'build', 'stage', 'buildchain-diagnostics');
+
+function platformId() {
+  return process.env.BUILDCHAIN_PLATFORM_ID || `${process.platform}-${process.arch}`;
+}
+
+function safeName(value) {
+  return String(value || 'unnamed')
+    .replace(/[^A-Za-z0-9_.-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function ensureDir(dir) {
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+function output(cmd, args, opts = {}) {
+  const result = childProcess.spawnSync(cmd, args, {
+    cwd: opts.cwd || rootDir,
+    env: opts.env || process.env,
+    encoding: 'utf8',
+    shell: opts.shell || false,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: opts.timeout || 15000,
+    windowsHide: true,
+  });
+  return {
+    command: [cmd, ...args].join(' '),
+    status: result.status,
+    stdout: (result.stdout || '').trim(),
+    stderr: (result.stderr || '').trim(),
+    error: result.error ? result.error.message : '',
+  };
+}
+
+function commandExists(command) {
+  const result =
+    process.platform === 'win32'
+      ? output('where', [command], { timeout: 5000 })
+      : output('sh', ['-c', `command -v ${command}`], { timeout: 5000 });
+  return result.status === 0 && result.stdout ? result.stdout.split(/\r?\n/)[0] : '';
+}
+
+function selectedEnv() {
+  const names = [
+    'BUILDCHAIN_SOURCE_SHA',
+    'BUILDCHAIN_SOURCE_REF',
+    'BUILDCHAIN_PLATFORM_ID',
+    'BUILDCHAIN_PLATFORM_NAME',
+    'BUILDCHAIN_VERSION',
+    'BUILDCHAIN_CHANNEL',
+    'RUNNER_NAME',
+    'RUNNER_OS',
+    'RUNNER_ARCH',
+    'RUNNER_TEMP',
+    'RUNNER_TOOL_CACHE',
+    'GITHUB_ACTION',
+    'GITHUB_ACTIONS',
+    'GITHUB_ACTOR',
+    'GITHUB_EVENT_NAME',
+    'GITHUB_JOB',
+    'GITHUB_REF',
+    'GITHUB_REF_NAME',
+    'GITHUB_REPOSITORY',
+    'GITHUB_RUN_ATTEMPT',
+    'GITHUB_RUN_ID',
+    'GITHUB_SHA',
+    'GITHUB_WORKSPACE',
+    'KF_COMPILER_CACHE',
+    'KF_NODE_DISABLE_NETWORK_FALLBACK',
+    'KF_NODE_GIT_MIRROR',
+    'KF_NODE_GIT_URL',
+    'KF_NODE_REFERENCE',
+    'KF_NODE_REFERENCE_IF_ABLE',
+    'KF_NODE_REFERENCE_REQUIRED',
+    'KF_PACK_MAIN_PACKAGE',
+    'KF_PACKAGE_STAGE_DIR',
+    'KF_SKIP_FALLBACK_BUILD',
+    'CC',
+    'CXX',
+    'CCACHE_BASEDIR',
+    'CCACHE_DIR',
+    'CCACHE_MAXSIZE',
+    'CMAKE_BUILD_PARALLEL_LEVEL',
+    'GYP_MSVS_VERSION',
+    'JOBS',
+    'MAKEFLAGS',
+    'NUMBER_OF_PROCESSORS',
+    'PYTHON',
+    'SCCACHE_CACHE_SIZE',
+    'SCCACHE_DIR',
+    'SCCACHE_IDLE_TIMEOUT',
+    'npm_config_jobs',
+  ];
+
+  const env = {};
+  for (const name of names) {
+    if (process.env[name] === undefined) continue;
+    env[name] = redact(name, process.env[name]);
+  }
+  return env;
+}
+
+function redact(name, value) {
+  if (/(TOKEN|PASSWORD|SECRET|KEY|AUTH|COOKIE|CREDENTIAL)/i.test(name)) return '<redacted>';
+  return value;
+}
+
+function readJsonIfExists(file) {
+  try {
+    if (!fs.existsSync(file)) return undefined;
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch (error) {
+    return { error: error.message };
+  }
+}
+
+async function buildchainToolkitSnapshot() {
+  try {
+    const buildchain = await import('@kungfu-tech/buildchain');
+    const loadedConfig = buildchain.loadBuildchainConfig(rootDir);
+    const validation = buildchain.validateBuildchainConfig(rootDir, {
+      requireVersionState: true,
+      requireLifecycleStages: ['install', 'build', 'verify', 'publish'],
+    });
+    const workspace = buildchain.getWorkspaceInfo ? buildchain.getWorkspaceInfo(rootDir) : undefined;
+
+    return {
+      import: '@kungfu-tech/buildchain',
+      versionStrategy: buildchain.getVersionStrategy(loadedConfig),
+      publish: buildchain.getPublishContract(loadedConfig),
+      anchorManifest: buildchain.loadConfiguredAnchorManifest(rootDir, loadedConfig),
+      lifecycleStages: {
+        install: buildchain.getLifecycleStage(loadedConfig, 'install'),
+        build: buildchain.getLifecycleStage(loadedConfig, 'build'),
+        verify: buildchain.getLifecycleStage(loadedConfig, 'verify'),
+        publish: buildchain.getLifecycleStage(loadedConfig, 'publish'),
+      },
+      packageManager: {
+        detected: buildchain.detectPackageManager ? buildchain.detectPackageManager(rootDir) : undefined,
+        workspace,
+      },
+      validation,
+    };
+  } catch (error) {
+    return {
+      import: '@kungfu-tech/buildchain',
+      error: error.message,
+    };
+  }
+}
+
+function statPath(file) {
+  try {
+    const stat = fs.lstatSync(file);
+    return {
+      exists: true,
+      type: stat.isSymbolicLink() ? 'symlink' : stat.isDirectory() ? 'directory' : stat.isFile() ? 'file' : 'other',
+      size: stat.size,
+      mtime: stat.mtime.toISOString(),
+      target: stat.isSymbolicLink() ? fs.readlinkSync(file) : undefined,
+    };
+  } catch (error) {
+    if (error.code === 'ENOENT') return { exists: false };
+    return { exists: false, error: error.message };
+  }
+}
+
+function dirStats(dir) {
+  const result = { path: path.relative(rootDir, dir) || '.', exists: false, files: 0, dirs: 0, symlinks: 0, bytes: 0 };
+  if (!fs.existsSync(dir)) return result;
+  result.exists = true;
+  const stack = [dir];
+  while (stack.length) {
+    const current = stack.pop();
+    let entries = [];
+    try {
+      entries = fs.readdirSync(current, { withFileTypes: true });
+    } catch (error) {
+      result.error = error.message;
+      continue;
+    }
+    for (const entry of entries) {
+      const full = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        result.dirs += 1;
+        stack.push(full);
+      } else if (entry.isSymbolicLink()) {
+        result.symlinks += 1;
+      } else if (entry.isFile()) {
+        result.files += 1;
+        try {
+          result.bytes += fs.statSync(full).size;
+        } catch {
+          // Best-effort diagnostics only.
+        }
+      }
+    }
+  }
+  return result;
+}
+
+function gitSnapshot() {
+  return {
+    rootHead: output('git', ['rev-parse', 'HEAD']),
+    rootStatus: output('git', ['status', '--short', '--untracked-files=no']),
+    nodeHead: output('git', ['-C', 'node', 'rev-parse', 'HEAD']),
+    nodeStatus: output('git', ['-C', 'node', 'status', '--short', '--untracked-files=no']),
+    nodeCountObjects: output('git', ['-C', 'node', 'count-objects', '-vH'], { timeout: 30000 }),
+  };
+}
+
+function toolSnapshot() {
+  const tools = {};
+  const commands = [
+    ['node', ['--version']],
+    ['corepack', ['--version']],
+    ['pnpm', ['--version']],
+    ['python', ['--version']],
+    ['python3', ['--version']],
+    ['git', ['--version']],
+    ['ccache', ['--version']],
+    ['sccache', ['--version']],
+    ['clang', ['--version']],
+    ['gcc', ['--version']],
+    ['cmake', ['--version']],
+    ['ninja', ['--version']],
+  ];
+  for (const [cmd, args] of commands) {
+    if (!commandExists(cmd)) continue;
+    tools[cmd] = output(cmd, args, { timeout: 15000 });
+  }
+  return tools;
+}
+
+function cacheSnapshot() {
+  const npmCache =
+    process.platform === 'win32'
+      ? output('cmd.exe', ['/c', 'npm config get cache 2>nul'])
+      : output('sh', ['-c', 'npm config get cache 2>/dev/null || true'], { timeout: 10000 });
+  const caches = {
+    ccacheStats: commandExists('ccache') ? output('ccache', ['-s'], { timeout: 30000 }) : undefined,
+    sccacheStats: commandExists('sccache') ? output('sccache', ['--show-stats'], { timeout: 30000 }) : undefined,
+    paths: {
+      ccacheDir: process.env.CCACHE_DIR ? statPath(process.env.CCACHE_DIR) : undefined,
+      sccacheDir: process.env.SCCACHE_DIR ? statPath(process.env.SCCACHE_DIR) : undefined,
+      npmCache,
+    },
+  };
+  return caches;
+}
+
+function platformSnapshot() {
+  const snapshot = {};
+  if (process.platform === 'darwin') {
+    snapshot.sysctl = output('sysctl', [
+      '-n',
+      'hw.ncpu',
+      'hw.physicalcpu',
+      'hw.logicalcpu',
+      'hw.perflevel0.physicalcpu',
+      'hw.perflevel0.logicalcpu',
+      'hw.perflevel1.physicalcpu',
+      'hw.perflevel1.logicalcpu',
+      'machdep.cpu.brand_string',
+    ]);
+    snapshot.xcode = commandExists('xcodebuild') ? output('xcodebuild', ['-version'], { timeout: 20000 }) : undefined;
+    snapshot.thermal = commandExists('pmset') ? output('pmset', ['-g', 'therm'], { timeout: 10000 }) : undefined;
+  } else if (process.platform === 'linux') {
+    snapshot.nproc = output('nproc', []);
+    snapshot.lscpu = output('lscpu', [], { timeout: 15000 });
+    snapshot.memory = output('free', ['-h']);
+  } else if (process.platform === 'win32') {
+    snapshot.version = output('cmd.exe', ['/c', 'ver']);
+    snapshot.processor = output(
+      'powershell.exe',
+      [
+        '-NoLogo',
+        '-NoProfile',
+        '-Command',
+        'Get-CimInstance Win32_Processor | Select-Object Name,NumberOfCores,NumberOfLogicalProcessors,MaxClockSpeed | ConvertTo-Json -Compress',
+      ],
+      { timeout: 20000 },
+    );
+    snapshot.cl = output('cmd.exe', ['/c', 'where cl']);
+  }
+  return snapshot;
+}
+
+async function snapshotPayload(phase) {
+  return {
+    schema: 1,
+    contract: 'kungfu-libnode-buildchain-diagnostics',
+    phase,
+    timestamp: nowIso(),
+    platform: {
+      id: platformId(),
+      processPlatform: process.platform,
+      processArch: process.arch,
+      runnerOs: process.env.RUNNER_OS || '',
+      runnerArch: process.env.RUNNER_ARCH || '',
+    },
+    process: {
+      pid: process.pid,
+      node: process.version,
+      execPath: process.execPath,
+      cwd: process.cwd(),
+      rootDir,
+    },
+    os: {
+      type: os.type(),
+      release: os.release(),
+      arch: os.arch(),
+      cpus: os.cpus().length,
+      totalmem: os.totalmem(),
+      freemem: os.freemem(),
+      loadavg: os.loadavg(),
+      uptime: os.uptime(),
+    },
+    env: selectedEnv(),
+    package: readJsonIfExists(path.join(rootDir, 'package.json')),
+    release: readJsonIfExists(path.join(rootDir, 'libnode.release.json')),
+    buildchain: await buildchainToolkitSnapshot(),
+    git: gitSnapshot(),
+    tools: toolSnapshot(),
+    caches: cacheSnapshot(),
+    platformDetails: platformSnapshot(),
+    paths: {
+      node: statPath(path.join(rootDir, 'node')),
+      distNode: statPath(path.join(rootDir, 'dist', 'node')),
+      buildStage: statPath(path.join(rootDir, 'build', 'stage')),
+      buildRelease: statPath(path.join(rootDir, 'build', 'Release')),
+    },
+    dirStats: {
+      dist: dirStats(path.join(rootDir, 'dist')),
+      buildStage: dirStats(path.join(rootDir, 'build', 'stage')),
+      buildNpm: dirStats(path.join(rootDir, 'build', 'npm')),
+    },
+  };
+}
+
+function writeJson(file, payload) {
+  ensureDir(path.dirname(file));
+  fs.writeFileSync(file, `${JSON.stringify(payload, null, 2)}\n`);
+}
+
+function appendStepSummary(markdown) {
+  if (!process.env.GITHUB_STEP_SUMMARY) return;
+  fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${markdown}\n`);
+}
+
+async function snapshot(phase) {
+  const payload = await snapshotPayload(phase);
+  const file = path.join(diagnosticsRoot, platformId(), `${safeName(phase)}.json`);
+  writeJson(file, payload);
+  console.log(`buildchain_diagnostics=${path.relative(rootDir, file).split(path.sep).join('/')}`);
+  appendStepSummary(
+    `### libnode diagnostics: ${phase}\n\n\`${path.relative(rootDir, file).split(path.sep).join('/')}\`\n`,
+  );
+  return payload;
+}
+
+function timingFile(name) {
+  return path.join(diagnosticsRoot, platformId(), `timing-${safeName(name)}.json`);
+}
+
+function writeTiming(name, start, end, status, extra = {}) {
+  const payload = {
+    schema: 1,
+    contract: 'kungfu-libnode-buildchain-timing',
+    name,
+    platform: platformId(),
+    startedAt: start.toISOString(),
+    endedAt: end.toISOString(),
+    durationMs: end.getTime() - start.getTime(),
+    status,
+    ...extra,
+  };
+  const file = timingFile(name);
+  writeJson(file, payload);
+  console.log(`buildchain_timing=${path.relative(rootDir, file).split(path.sep).join('/')}`);
+  appendStepSummary(`- ${name}: ${payload.durationMs} ms (${status})`);
+  return payload;
+}
+
+function timeSync(name, fn) {
+  const start = new Date();
+  console.log(`::group::libnode ${name}`);
+  try {
+    const value = fn();
+    writeTiming(name, start, new Date(), 'ok');
+    return value;
+  } catch (error) {
+    writeTiming(name, start, new Date(), 'failed', { error: error.message });
+    throw error;
+  } finally {
+    console.log('::endgroup::');
+  }
+}
+
+function timeCommand(name, command, args) {
+  return timeSync(name, () => {
+    console.log(`$ ${command} ${args.join(' ')}`);
+    const result = childProcess.spawnSync(command, args, {
+      cwd: rootDir,
+      env: process.env,
+      shell: process.platform === 'win32',
+      stdio: 'inherit',
+      windowsHide: true,
+    });
+    if (result.status !== 0) {
+      process.exit(result.status === null ? 1 : result.status);
+    }
+    return result;
+  });
+}
+
+function printUsage() {
+  console.error('usage: node .gyp/buildchain-diagnostics.js snapshot <phase>');
+  console.error('   or: node .gyp/buildchain-diagnostics.js time <name> -- <command> [args...]');
+}
+
+async function main() {
+  const [command, name, separator, ...rest] = process.argv.slice(2);
+  if (command === 'snapshot' && name) {
+    await snapshot(name);
+    return;
+  }
+  if (command === 'time' && name && separator === '--' && rest.length) {
+    timeCommand(name, rest[0], rest.slice(1));
+    return;
+  }
+  printUsage();
+  process.exit(2);
+}
+
+module.exports = {
+  snapshot,
+  timeSync,
+};
+
+if (require.main === module)
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/.gyp/buildchain-install.js
+++ b/.gyp/buildchain-install.js
@@ -1,4 +1,5 @@
 const { exitOnError, run } = require('./node-lib.js');
+const { snapshot, timeSync } = require('./buildchain-diagnostics.js');
 
 const [nodeGitUrl, nodeReference] = process.argv.slice(2);
 
@@ -11,8 +12,11 @@ if (nodeReference) {
 }
 
 async function main() {
-  run('corepack', ['pnpm', 'install', '--frozen-lockfile', '--ignore-scripts']);
-  run('corepack', ['pnpm', 'prepare-node-source']);
+  await snapshot('install-start');
+  timeSync('pnpm-install', () => run('corepack', ['pnpm', 'install', '--frozen-lockfile', '--ignore-scripts']));
+  await snapshot('install-after-pnpm');
+  timeSync('prepare-node-source', () => run('corepack', ['pnpm', 'prepare-node-source']));
+  await snapshot('install-end');
 }
 
 if (require.main === module) main().catch(exitOnError);

--- a/.gyp/buildchain-validate.js
+++ b/.gyp/buildchain-validate.js
@@ -1,0 +1,29 @@
+const path = require('path');
+
+const rootDir = path.resolve(__dirname, '..');
+
+function lifecycleSummary(validation) {
+  return (validation.lifecycleStages || []).map((stage) => `${stage.name}:${stage.mode}`).join(', ');
+}
+
+async function main() {
+  const buildchain = await import('@kungfu-tech/buildchain');
+  const loadedConfig = buildchain.loadBuildchainConfig(rootDir);
+  const validation = buildchain.validateBuildchainConfig(rootDir, {
+    requireVersionState: true,
+    requireLifecycleStages: ['install', 'build', 'verify', 'publish'],
+  });
+  const versionStrategy = buildchain.getVersionStrategy(loadedConfig);
+  const publish = buildchain.getPublishContract(loadedConfig);
+
+  console.log(
+    `buildchain config ok: ${versionStrategy.strategy}/${versionStrategy.next}, lifecycle [${lifecycleSummary(
+      validation,
+    )}], publish ${publish.mode}`,
+  );
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/.gyp/node-build.js
+++ b/.gyp/node-build.js
@@ -3,6 +3,7 @@ const path = require('path');
 const sywac = require('sywac');
 const { prepareWindowsPythonEnv } = require('./build-env.js');
 const { exitOnError, run } = require('./node-lib.js');
+const { snapshot, timeSync } = require('./buildchain-diagnostics.js');
 
 const rootDir = path.dirname(__dirname);
 const nodeGyp = require.resolve('node-gyp/bin/node-gyp.js');
@@ -10,14 +11,16 @@ const addonModuleName = 'link_node';
 
 function runNodeGyp(args) {
   prepareWindowsPythonEnv(process.env);
-  run(process.execPath, [nodeGyp, `--module_name=${addonModuleName}`, ...args], {
+  return run(process.execPath, [nodeGyp, `--module_name=${addonModuleName}`, ...args], {
     cwd: rootDir,
     env: process.env,
   });
 }
 
 async function build() {
-  runNodeGyp(['configure', 'build']);
+  await snapshot('node-gyp-build-start');
+  timeSync('node-gyp-configure-build', () => runNodeGyp(['configure', 'build']));
+  await snapshot('node-gyp-build-end');
 }
 
 async function clean() {

--- a/.gyp/node-dist.js
+++ b/.gyp/node-dist.js
@@ -3,6 +3,7 @@ const fse = require('fs-extra');
 const { globSync } = require('glob');
 const path = require('path');
 const sywac = require('sywac');
+const { snapshot, timeSync } = require('./buildchain-diagnostics.js');
 
 const rootDir = path.dirname(__dirname);
 
@@ -58,7 +59,9 @@ module.exports = cli;
 
 async function main() {
   const argv = await cli.parseAndExit();
-  dist(argv['build-type']);
+  await snapshot('node-dist-start');
+  timeSync('node-dist-assemble', () => dist(argv['build-type']));
+  await snapshot('node-dist-end');
 }
 
 if (require.main === module) main().catch(exitOnError);

--- a/.gyp/node-make.js
+++ b/.gyp/node-make.js
@@ -6,6 +6,7 @@ const path = require('path');
 const os = require('os');
 const sywac = require('sywac');
 const convert = require('xml-js');
+const { snapshot, timeSync } = require('./buildchain-diagnostics.js');
 
 const arch = process.arch;
 const rootDir = path.dirname(__dirname);
@@ -84,22 +85,24 @@ function prepareCompilerCache() {
   if (mode === '0' || mode === 'false' || mode === 'off' || mode === 'none') return [];
 
   if (process.platform === 'win32') {
-    return prepareWindowsCompilerCache(mode);
+    return timeSync('prepare-windows-compiler-cache', () => prepareWindowsCompilerCache(mode));
   }
 
-  if (!prepareUnixCompilerCache(mode)) {
+  if (!timeSync('prepare-unix-compiler-cache', () => prepareUnixCompilerCache(mode))) {
     console.log('compiler cache: unavailable');
   }
   return [];
 }
 
 function showCompilerCacheStats() {
-  if (process.env.CCACHE_DIR && commandExists('ccache')) {
-    runCacheTool('ccache', ['--show-stats']);
-  }
-  if (process.env.SCCACHE_DIR && commandExists('sccache')) {
-    runCacheTool('sccache', ['--show-stats']);
-  }
+  timeSync('compiler-cache-stats', () => {
+    if (process.env.CCACHE_DIR && commandExists('ccache')) {
+      runCacheTool('ccache', ['--show-stats']);
+    }
+    if (process.env.SCCACHE_DIR && commandExists('sccache')) {
+      runCacheTool('sccache', ['--show-stats']);
+    }
+  });
 }
 
 function cleanNodeBuildState() {
@@ -167,20 +170,27 @@ const runWinPatch = () => {
 
 const buildWin = () => {
   patchEnv();
-  cleanNodeBuildState();
-  prepareWindowsPythonEnv();
+  timeSync('clean-node-build-state', cleanNodeBuildState);
+  timeSync('prepare-windows-python-env', prepareWindowsPythonEnv);
   const cacheArgs = prepareCompilerCache();
-  run(path.join('.', 'vcbuild.bat'), ['dll', arch, 'release', 'projgen', 'nobuild', ...cacheArgs], { cwd: nodeSrcDir });
-  runWinPatch();
-  run(path.join('.', 'vcbuild.bat'), ['dll', 'noprojgen', ...cacheArgs], { cwd: nodeSrcDir });
+  timeSync('vcbuild-projgen', () =>
+    run(path.join('.', 'vcbuild.bat'), ['dll', arch, 'release', 'projgen', 'nobuild', ...cacheArgs], {
+      cwd: nodeSrcDir,
+    }),
+  );
+  timeSync('windows-vcxproj-patch', runWinPatch);
+  timeSync('vcbuild-dll', () =>
+    run(path.join('.', 'vcbuild.bat'), ['dll', 'noprojgen', ...cacheArgs], { cwd: nodeSrcDir }),
+  );
   showCompilerCacheStats();
 };
 
 const buildUnix = () => {
-  cleanNodeBuildState();
+  timeSync('clean-node-build-state', cleanNodeBuildState);
   prepareCompilerCache();
-  run('sh', [path.join('.', 'configure'), '--shared'], { cwd: nodeSrcDir });
-  run('make', ['-j', `${buildJobs()}`], { cwd: nodeSrcDir });
+  console.log(`build jobs: ${buildJobs()}`);
+  timeSync('node-configure-shared', () => run('sh', [path.join('.', 'configure'), '--shared'], { cwd: nodeSrcDir }));
+  timeSync('node-make-shared', () => run('make', ['-j', `${buildJobs()}`], { cwd: nodeSrcDir }));
   showCompilerCacheStats();
 };
 
@@ -220,8 +230,10 @@ module.exports = cli;
 
 async function main() {
   const argv = await cli.parseAndExit();
-  build();
-  stamp(argv['build-type']);
+  await snapshot('node-make-start');
+  timeSync('node-native-build', build);
+  timeSync('node-native-stamp', () => stamp(argv['build-type']));
+  await snapshot('node-make-end');
 }
 
 if (require.main === module && !process.env.KF_SKIP_MAKE_LIBNODE) main().catch(exitOnError);

--- a/.gyp/node-platform-package.js
+++ b/.gyp/node-platform-package.js
@@ -4,6 +4,7 @@ const { globSync } = require('glob');
 const path = require('path');
 const sywac = require('sywac');
 const { exitOnError } = require('./node-lib.js');
+const { snapshot, timeSync } = require('./buildchain-diagnostics.js');
 
 const rootDir = path.dirname(__dirname);
 const distDir = path.join(rootDir, 'dist', 'node');
@@ -336,22 +337,25 @@ function shouldPackMain() {
 }
 
 async function packMain() {
-  npmPack(prepareMainPackage());
+  timeSync('prepare-main-package', () => npmPack(prepareMainPackage()));
 }
 
 async function packPlatform() {
-  npmPack(preparePlatformPackage(currentPlatformPackage()));
+  timeSync('prepare-platform-package', () => npmPack(preparePlatformPackage(currentPlatformPackage())));
 }
 
 async function pack() {
+  await snapshot('package-start');
   await packPlatform();
 
   if (shouldPackMain()) {
     await packMain();
   }
+  await snapshot('package-end');
 }
 
 async function verifySource() {
+  await snapshot('verify-package-source-start');
   const sourcePackageJson = rootPackageJson();
   const scripts = sourcePackageJson.scripts || {};
 
@@ -378,6 +382,7 @@ async function verifySource() {
       throw new Error(`Unexpected platform package name: ${descriptor.name}`);
     }
   }
+  await snapshot('verify-package-source-end');
 }
 
 async function main() {

--- a/.gyp/node-source-prepare.js
+++ b/.gyp/node-source-prepare.js
@@ -1,6 +1,7 @@
 const childProcess = require('child_process');
 const fs = require('fs');
 const path = require('path');
+const { snapshot, timeSync } = require('./buildchain-diagnostics.js');
 
 const repoRoot = path.resolve(__dirname, '..');
 const release = JSON.parse(fs.readFileSync(path.join(repoRoot, 'libnode.release.json'), 'utf8'));
@@ -166,7 +167,8 @@ function updateFrom(url, referencePath) {
   return false;
 }
 
-function main() {
+async function main() {
+  await snapshot('node-source-prepare-start');
   const gitmodulesTag = gitmodules('submodule.node.tag');
   if (gitmodulesTag !== release.nodeTag) {
     throw new Error(`node submodule tag mismatch: expected ${release.nodeTag}, got ${gitmodulesTag}`);
@@ -174,15 +176,19 @@ function main() {
 
   if (nodeIsReady()) {
     console.log(`node source already prepared: ${release.nodeCommit}`);
+    await snapshot('node-source-prepare-ready');
     return;
   }
 
   const configuredUrl =
     process.env.KF_NODE_GIT_URL || process.env.KF_NODE_GIT_MIRROR || gitmodules('submodule.node.url') || defaultNodeUrl;
   const referencePath = usableReferencePath();
-  resetIncompleteNodeCheckout();
-  if (updateFrom(configuredUrl, referencePath)) {
-    if (nodeIsReady()) return;
+  timeSync('node-source-reset-incomplete-checkout', resetIncompleteNodeCheckout);
+  if (timeSync('node-source-update-configured', () => updateFrom(configuredUrl, referencePath))) {
+    if (nodeIsReady()) {
+      await snapshot('node-source-prepare-end');
+      return;
+    }
     throw new Error(`node checkout mismatch after update: expected ${release.nodeCommit}, got ${currentNodeHead()}`);
   }
 
@@ -191,9 +197,13 @@ function main() {
   }
 
   console.warn(`retrying node source prepare from ${defaultNodeUrl}`);
-  if (!updateFrom(defaultNodeUrl, referencePath) || !nodeIsReady()) {
+  if (!timeSync('node-source-update-default', () => updateFrom(defaultNodeUrl, referencePath)) || !nodeIsReady()) {
     throw new Error(`node checkout mismatch after fallback: expected ${release.nodeCommit}, got ${currentNodeHead()}`);
   }
+  await snapshot('node-source-prepare-end');
 }
 
-main();
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/buildchain.toml
+++ b/buildchain.toml
@@ -31,23 +31,27 @@ KF_COMPILER_CACHE = "auto"
 [lifecycle.install]
 timeout_minutes = 10
 commands = [
-  "corepack pnpm install --frozen-lockfile --ignore-scripts",
-  "corepack pnpm prepare-node-source",
+  "node .gyp/buildchain-install.js",
 ]
 
 [lifecycle.build]
 timeout_minutes = 240
 commands = [
+  "node .gyp/buildchain-diagnostics.js snapshot lifecycle-build-start",
   "corepack pnpm build",
+  "node .gyp/buildchain-diagnostics.js snapshot lifecycle-build-after-node-gyp",
   "corepack pnpm package",
+  "node .gyp/buildchain-diagnostics.js snapshot lifecycle-build-end",
 ]
 
 [lifecycle.verify]
 timeout_minutes = 10
 commands = [
+  "node .gyp/buildchain-diagnostics.js snapshot lifecycle-verify-start",
   "corepack pnpm verify-release",
   "corepack pnpm verify-package-source",
   "git diff --check",
+  "node .gyp/buildchain-diagnostics.js snapshot lifecycle-verify-end",
 ]
 
 [lifecycle.publish]

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "rebuild": "node .gyp/node-build.js rebuild",
     "verify-release": "node .gyp/libnode-release-verify.js",
     "verify-package-source": "node .gyp/node-platform-package.js verify-source",
+    "buildchain:validate": "node .gyp/buildchain-validate.js",
     "format": "prettier --write --parser typescript .gyp/*.js src/js/*.js"
   },
   "packageManager": "pnpm@11.9.0",
@@ -44,6 +45,7 @@
     "sywac": "^1.3.0"
   },
   "devDependencies": {
+    "@kungfu-tech/buildchain": "2.2.5",
     "fs-extra": "^11.3.6",
     "glob": "^13.0.6",
     "node-addon-api": "^8.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ importers:
         specifier: ^1.3.0
         version: 1.3.0
     devDependencies:
+      '@kungfu-tech/buildchain':
+        specifier: 2.2.5
+        version: 2.2.5
       fs-extra:
         specifier: ^11.3.6
         version: 11.3.6
@@ -36,6 +39,11 @@ packages:
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
+
+  '@kungfu-tech/buildchain@2.2.5':
+    resolution: {integrity: sha512-QxXUtxOhhbiInZHWZz2yQPsILWec/Ab9/YmoA3uPc1eqYD6/cofaw7C7N+xUrCOk6qht2BaIWeiG3aurazbuKg==}
+    engines: {node: '>=22.14.0'}
+    hasBin: true
 
   abbrev@5.0.0:
     resolution: {integrity: sha512-/XrFJgzQQQHpti1raDJC6m4ws6aNktmjBlhk8Fdlk7LwCEuDoieEJJY9OFHjfiFJFFRM2tK+Ky/IsfbbmlMu1w==}
@@ -143,6 +151,10 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  smol-toml@1.7.0:
+    resolution: {integrity: sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==}
+    engines: {node: '>= 18'}
+
   sywac@1.3.0:
     resolution: {integrity: sha512-LDt2stNTp4bVPMgd70Jj9PWrSa4batl+bv+Ea5NLNGT7ufc4oQPtRfQ73wbddNV6RilaPqnEt6y1Wkm5FVTNEg==}
     engines: {node: '>=4'}
@@ -181,6 +193,10 @@ snapshots:
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
       minipass: 7.1.3
+
+  '@kungfu-tech/buildchain@2.2.5':
+    dependencies:
+      smol-toml: 1.7.0
 
   abbrev@5.0.0: {}
 
@@ -267,6 +283,8 @@ snapshots:
   sax@1.6.0: {}
 
   semver@7.8.5: {}
+
+  smol-toml@1.7.0: {}
 
   sywac@1.3.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@kungfu-tech/buildchain@2.2.5'


### PR DESCRIPTION
## Summary
- add buildchain toolkit validation through the package JS API
- capture libnode build diagnostics and timing snapshots across install, build, verify, package, and source preparation
- pin @kungfu-tech/buildchain 2.2.5 for the diagnostics integration

## Verification
- corepack pnpm install --frozen-lockfile
- corepack pnpm run buildchain:validate
- node .gyp/libnode-release-verify.js
- npm pack --dry-run --json --registry=https://registry.npmjs.org/
- node -c .gyp/buildchain-diagnostics.js
- node -c .gyp/buildchain-validate.js
- corepack pnpm exec prettier --check .gyp/*.js src/js/*.js
- git diff --check
