### PR TITLE
ci: authorize buildchain diagnostics alpha publish

### DIFF
--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -16,9 +16,9 @@ concurrency:
 
 jobs:
   build:
-    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@v2
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@feature/toolkit-diagnostics-feedback
     with:
-      buildchain-ref: v2
+      buildchain-ref: feature/toolkit-diagnostics-feedback
       runner-preset: kungfu-v4-self-hosted
       publish-channel: ${{ startsWith(github.ref_name, 'publish-gate/alpha/') && 'alpha' || startsWith(github.ref_name, 'publish-gate/release/') && 'release' || 'major' }}
       publish-source-ref: ${{ github.ref_name }}
@@ -116,7 +116,7 @@ jobs:
           KF_NPM_EXPECTED_VERSION: ${{ fromJSON(needs.build.outputs.release-manifest-json).anchorManifest.summary.npmVersion }}
 
       - name: Promote release ref and publish npm package set
-        uses: kungfu-systems/buildchain/actions/promote-buildchain-ref@v2
+        uses: kungfu-systems/buildchain/actions/promote-buildchain-ref@feature/toolkit-diagnostics-feedback
         env:
           KF_NPM_DIST_TAG: ${{ needs.build.outputs.publish-channel == 'alpha' && 'alpha' || 'latest' }}
           KF_NPM_EXPECTED_VERSION: ${{ fromJSON(needs.build.outputs.release-manifest-json).anchorManifest.summary.npmVersion }}

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -3,8 +3,9 @@ name: Release - New Version
 on:
   push:
     branches:
-      - alpha/v*/v*.*
-      - release/v*/v*.*
+      - publish-gate/alpha/**
+      - publish-gate/release/**
+      - publish-gate/major
 
 permissions:
   contents: read
@@ -19,7 +20,8 @@ jobs:
     with:
       buildchain-ref: v2
       runner-preset: kungfu-v4-self-hosted
-      publish-channel: ${{ startsWith(github.ref_name, 'alpha/') && 'alpha' || 'release' }}
+      publish-channel: ${{ startsWith(github.ref_name, 'publish-gate/alpha/') && 'alpha' || startsWith(github.ref_name, 'publish-gate/release/') && 'release' || 'major' }}
+      publish-source-ref: ${{ github.ref_name }}
       setup-node: true
       node-version: '24'
       install-command: node .gyp/buildchain-install.js "${{ vars.KF_NODE_GIT_URL }}" "${{ vars.KF_NODE_REFERENCE }}"
@@ -73,8 +75,14 @@ jobs:
           if (manifest.sourceSha !== sourceSha) {
             throw new Error(`manifest sourceSha ${manifest.sourceSha} != ${sourceSha}`);
           }
-          if (manifest.channel !== 'none') {
-            throw new Error(`channel branch release must not use publish-gate source lock, got ${manifest.channel}`);
+          if (!manifest.sourceLocked) {
+            throw new Error('release publication requires a publish-gate source lock');
+          }
+          if (!['alpha', 'release', 'major'].includes(manifest.channel)) {
+            throw new Error(`unsupported publish-gate channel: ${manifest.channel}`);
+          }
+          if ((manifest.channel === 'alpha' || manifest.channel === 'release') && !manifest.consumerVersion) {
+            throw new Error('publish-gate alpha/release source lock must include a consumer version');
           }
           const npmVersion = manifest.anchorManifest?.summary?.npmVersion;
           if (!npmVersion) throw new Error('manifest anchor npmVersion is required');
@@ -82,7 +90,10 @@ jobs:
           if (!versionFile || versionFile.version !== npmVersion) {
             throw new Error(`package.json version ${versionFile?.version || '<missing>'} != anchor npmVersion ${npmVersion}`);
           }
-          console.log(`manifest ok: ${channel} ${npmVersion} ${sourceSha}`);
+          if (manifest.consumerVersion && manifest.consumerVersion !== npmVersion) {
+            throw new Error(`publish-gate consumer version ${manifest.consumerVersion} != anchor npmVersion ${npmVersion}`);
+          }
+          console.log(`manifest ok: ${channel} ${manifest.sourceRef} ${npmVersion} ${sourceSha}`);
           NODE
         env:
           BUILDCHAIN_RELEASE_MANIFEST_JSON: ${{ needs.build.outputs.release-manifest-json }}
@@ -112,7 +123,7 @@ jobs:
         with:
           token: ${{ secrets.BUILDCHAIN_PROMOTION_TOKEN || github.token }}
           sha: ${{ needs.build.outputs.publish-source-sha }}
-          target-ref: ${{ github.ref_name }}
+          target-ref: ${{ needs.build.outputs.publish-source-channel == 'major' && 'publish-gate/major' || format('{0}/{1}', needs.build.outputs.publish-source-channel, needs.build.outputs.publish-source-line) }}
           allow-repository: ${{ github.repository }}
           require-governance: 'true'
           require-version-state: 'true'
@@ -123,4 +134,8 @@ jobs:
           publish-dist-tag: ${{ needs.build.outputs.publish-channel == 'alpha' && 'alpha' || 'latest' }}
           publish-package-set-order: platforms-first-main-last
           publish-package-main: '@kungfu-tech/libnode'
+          require-publish-source-lock: 'true'
+          publish-source-ref: ${{ needs.build.outputs.publish-source-ref }}
+          publish-source-sha: ${{ needs.build.outputs.publish-source-sha }}
+          publish-source-locked: ${{ needs.build.outputs.publish-source-locked }}
           publish-required-artifacts-json: ${{ steps.evidence.outputs.required-artifacts-json }}

--- a/README.md
+++ b/README.md
@@ -32,11 +32,15 @@ node -p "require('@kungfu-tech/libnode').include"
 
 The `Build` and `Release - Verify` workflows run through Kungfu Buildchain and build the Node.js version pinned by `libnode.release.json` and `.gitmodules`. Each runner packages its native output as an npm platform tarball under `build/stage/npm`.
 
-Npm publication is handled only by Buildchain channel promotion. A reviewed
-merge into `alpha/vN/vN.M` publishes the package set with dist-tag `alpha`; a
-reviewed merge into `release/vN/vN.M` publishes the final package set with
-dist-tag `latest`. The exact npm version is read from `package.json` and
-`libnode.release.json`, not from the branch name.
+Npm publication is handled only by Buildchain publish-gate promotion. Reviewed
+channel branches prepare release material; package publication enters through
+`publish-gate/alpha/<line>/<version>` for dist-tag `alpha` or
+`publish-gate/release/<line>/<version>` for dist-tag `latest`. The reusable
+Buildchain workflow locks that gate branch to an exact source SHA before build
+and publish, and the promotion action rejects publish side effects unless the
+same source-lock protocol is present. The exact npm version is read from
+`package.json` and `libnode.release.json`, and must match the publish-gate
+consumer version.
 
 npm publication uses GitHub Trusted Publishing from the GitHub-hosted publish
 job. The workflow does not use `NPM_PUSH_TOKEN` or npm dist-tag recovery tokens

--- a/libnode.release.json
+++ b/libnode.release.json
@@ -4,5 +4,5 @@
   "nodeTag": "v22.22.3",
   "nodeCommit": "fdfa0ff0dbaf0fbf4d7d6d89a2ab807f3177fa5c",
   "libnodeRevision": 3,
-  "npmVersion": "22.22.3-kf.3-alpha.0"
+  "npmVersion": "22.22.3-kf.3-alpha.2"
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "name": "kungfu-trader",
     "email": "info@kungfu.link"
   },
-  "version": "22.22.3-kf.3-alpha.0",
+  "version": "22.22.3-kf.3-alpha.2",
   "description": "Build shared node lib",
   "license": "Apache-2.0",
   "main": "src/js/index.js",


### PR DESCRIPTION
Authorize the Buildchain diagnostics dogfood alpha source for 22.22.3-kf.3-alpha.2.\n\nEvidence before alpha authorization:\n- Release - New Version run 28604378358 completed all native platform build/verify jobs.\n- Windows x64, Linux x64, and macOS ARM64 uploaded deterministic artifacts, artifact manifests, and diagnostics artifacts.\n- Buildchain aggregate summary and aggregate diagnostics summary jobs completed.\n- npm publish did not run because alpha/v22/v22.22 was still locked to the previous alpha source SHA.\n\nThis PR targets only the alpha line; it is not a release/latest publication.