### PR TITLE
release: publish libnode 22.22.3-kf.3-alpha.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,9 +18,8 @@ concurrency:
 
 jobs:
   build:
-    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@v2
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@v2.4.1
     with:
-      buildchain-ref: v2
       runner-preset: kungfu-v4-self-hosted
       setup-node: true
       node-version: '24'

--- a/.github/workflows/buildchain-preflight.yml
+++ b/.github/workflows/buildchain-preflight.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v7.0.0
 
       - name: Validate Buildchain config
-        uses: kungfu-systems/buildchain/actions/validate-config@v2
+        uses: kungfu-systems/buildchain/actions/validate-config@v2.4.1
         with:
           config-required: 'true'
           require-version-state: 'true'

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -16,9 +16,8 @@ concurrency:
 
 jobs:
   build:
-    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@feature/toolkit-diagnostics-feedback
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@v2.4.1
     with:
-      buildchain-ref: feature/toolkit-diagnostics-feedback
       runner-preset: kungfu-v4-self-hosted
       publish-channel: ${{ startsWith(github.ref_name, 'publish-gate/alpha/') && 'alpha' || startsWith(github.ref_name, 'publish-gate/release/') && 'release' || 'major' }}
       publish-source-ref: ${{ github.ref_name }}
@@ -116,7 +115,7 @@ jobs:
           KF_NPM_EXPECTED_VERSION: ${{ fromJSON(needs.build.outputs.release-manifest-json).anchorManifest.summary.npmVersion }}
 
       - name: Promote release ref and publish npm package set
-        uses: kungfu-systems/buildchain/actions/promote-buildchain-ref@feature/toolkit-diagnostics-feedback
+        uses: kungfu-systems/buildchain/actions/promote-buildchain-ref@v2.4.1
         env:
           KF_NPM_DIST_TAG: ${{ needs.build.outputs.publish-channel == 'alpha' && 'alpha' || 'latest' }}
           KF_NPM_EXPECTED_VERSION: ${{ fromJSON(needs.build.outputs.release-manifest-json).anchorManifest.summary.npmVersion }}
@@ -129,6 +128,7 @@ jobs:
           require-version-state: 'true'
           required-status-check: 'build'
           publish-transaction: 'true'
+          release-passport-product-name: Libnode
           publish-mode: publish-final-version
           publish-auth: trusted-publishing
           publish-dist-tag: ${{ needs.build.outputs.publish-channel == 'alpha' && 'alpha' || 'latest' }}

--- a/.github/workflows/release-verify.yaml
+++ b/.github/workflows/release-verify.yaml
@@ -16,9 +16,8 @@ concurrency:
 
 jobs:
   build:
-    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@v2
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@v2.4.1
     with:
-      buildchain-ref: v2
       runner-preset: kungfu-v4-self-hosted
       setup-node: true
       node-version: '24'

--- a/.gyp/node-lib.js
+++ b/.gyp/node-lib.js
@@ -25,8 +25,14 @@ exports.run = function (cmd, argv, opts = {}) {
     windowsHide: true,
     ...opts,
   });
-  if (opts.check && result.status !== 0) {
-    process.exit(result.status);
+  if (opts.check && (result.error || result.status === null || result.status !== 0)) {
+    if (result.error) {
+      console.error(result.error.message);
+    }
+    if (result.signal) {
+      console.error(`${cmd} exited with signal ${result.signal}`);
+    }
+    process.exit(result.status === null ? 1 : result.status);
   }
   return result;
 };

--- a/.gyp/node-make.js
+++ b/.gyp/node-make.js
@@ -165,6 +165,26 @@ const runWinPatch = () => {
   });
 };
 
+function listExistingFiles(dirs) {
+  return dirs.flatMap((dir) => {
+    if (!fs.existsSync(dir)) return [];
+    return fs.readdirSync(dir).map((entry) => path.join(dir, entry));
+  });
+}
+
+function assertNodeBuildOutput(buildType) {
+  const files = listExistingFiles([path.join(nodeSrcDir, buildType), path.join(nodeSrcDir, 'out', buildType)]);
+  const pattern =
+    process.platform === 'win32'
+      ? /^libnode.*\.(dll|lib)$/i
+      : process.platform === 'darwin'
+        ? /^libnode\.\d+\.dylib$/
+        : /^libnode\.so\.\d+$/;
+  if (!files.some((file) => pattern.test(path.basename(file)))) {
+    throw new Error(`Missing ${process.platform}-${arch} libnode binary after make`);
+  }
+}
+
 const buildWin = () => {
   patchEnv();
   cleanNodeBuildState();
@@ -221,11 +241,13 @@ module.exports = cli;
 async function main() {
   const argv = await cli.parseAndExit();
   if (flag('KF_SKIP_MAKE_LIBNODE')) {
+    assertNodeBuildOutput(argv['build-type']);
     console.log('libnode make skipped; stamping existing build output');
     stamp(argv['build-type']);
     return;
   }
   build();
+  assertNodeBuildOutput(argv['build-type']);
   stamp(argv['build-type']);
 }
 

--- a/.gyp/node-make.js
+++ b/.gyp/node-make.js
@@ -220,8 +220,13 @@ module.exports = cli;
 
 async function main() {
   const argv = await cli.parseAndExit();
+  if (flag('KF_SKIP_MAKE_LIBNODE')) {
+    console.log('libnode make skipped; stamping existing build output');
+    stamp(argv['build-type']);
+    return;
+  }
   build();
   stamp(argv['build-type']);
 }
 
-if (require.main === module && !process.env.KF_SKIP_MAKE_LIBNODE) main().catch(exitOnError);
+if (require.main === module) main().catch(exitOnError);

--- a/buildchain.toml
+++ b/buildchain.toml
@@ -28,6 +28,27 @@ main_package = "@kungfu-tech/libnode"
 KF_SKIP_FALLBACK_BUILD = "true"
 KF_COMPILER_CACHE = "auto"
 
+[diagnostics.native]
+enabled = true
+sample_process_tree = true
+compiler_cache = "auto"
+expected_tools = ["node", "pnpm", "git", "python", "make", "cmake", "ninja", "ccache", "sccache", "clang", "cl"]
+artifact_dirs = ["dist/node", "build/Release", "build/stage", "build/npm", "node/out/Release"]
+cache_dirs = [
+  "/Users/gha-runner/.cache/kungfu/build-cache/ccache/libnode/darwin-arm64",
+  "/Users/gha-runner/.cache/kungfu/build-cache/sccache/libnode/darwin-arm64",
+  "/home/gha-runner/.cache/kungfu/build-cache/ccache/libnode/linux-x64",
+  "/home/gha-runner/.cache/kungfu/build-cache/sccache/libnode/linux-x64",
+  "/home/runner/.cache/kungfu/build-cache/ccache/libnode/linux-x64",
+  "/home/runner/.cache/kungfu/build-cache/sccache/libnode/linux-x64",
+  "/data/actions-runner/.cache/kungfu/build-cache/ccache/libnode/linux-x64",
+  "/data/actions-runner/.cache/kungfu/build-cache/sccache/libnode/linux-x64",
+  "C:/Users/gha-runner/AppData/Local/Kungfu/build-cache/ccache/libnode/win32-x64",
+  "C:/Users/gha-runner/AppData/Local/Kungfu/build-cache/sccache/libnode/win32-x64",
+  "C:/Users/runneradmin/AppData/Local/Kungfu/build-cache/ccache/libnode/win32-x64",
+  "C:/Users/runneradmin/AppData/Local/Kungfu/build-cache/sccache/libnode/win32-x64",
+]
+
 [lifecycle.install]
 timeout_minutes = 10
 commands = [

--- a/buildchain.toml
+++ b/buildchain.toml
@@ -59,7 +59,8 @@ commands = [
 [lifecycle.build]
 timeout_minutes = 240
 commands = [
-  "corepack pnpm build",
+  "corepack pnpm make",
+  "node .gyp/run-with-env.js KF_SKIP_MAKE_LIBNODE=true -- corepack pnpm build",
   "corepack pnpm package",
 ]
 

--- a/libnode.release.json
+++ b/libnode.release.json
@@ -4,5 +4,5 @@
   "nodeTag": "v22.22.3",
   "nodeCommit": "fdfa0ff0dbaf0fbf4d7d6d89a2ab807f3177fa5c",
   "libnodeRevision": 3,
-  "npmVersion": "22.22.3-kf.3-alpha.3"
+  "npmVersion": "22.22.3-kf.3-alpha.4"
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "name": "kungfu-trader",
     "email": "info@kungfu.link"
   },
-  "version": "22.22.3-kf.3-alpha.3",
+  "version": "22.22.3-kf.3-alpha.4",
   "description": "Build shared node lib",
   "license": "Apache-2.0",
   "main": "src/js/index.js",


### PR DESCRIPTION
## Summary
- merge dev/v22/v22.22 buildchain 2.4.1 diagnostics changes into alpha/v22/v22.22
- advance anchored libnode alpha version to 22.22.3-kf.3-alpha.4
- prepare alpha channel ref so publish-gate source SHA and target alpha ref match buildchain 2.4.1 release passport semantics

## Validation
- dev PR #35 Build and Buildchain Preflight passed
- publish-gate run 28662820381 built all three platform artifacts successfully but failed before npm publish because alpha/v22/v22.22 still pointed at the previous alpha SHA
- this PR updates alpha via branch protection instead of direct protected-branch push