### PR TITLE
release: publish libnode 22.22.3-kf.3-alpha.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   build:
-    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@v2.4.1
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@v2
     with:
       runner-preset: kungfu-v4-self-hosted
       setup-node: true

--- a/.github/workflows/buildchain-preflight.yml
+++ b/.github/workflows/buildchain-preflight.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v7.0.0
 
       - name: Validate Buildchain config
-        uses: kungfu-systems/buildchain/actions/validate-config@v2.4.1
+        uses: kungfu-systems/buildchain/actions/validate-config@v2
         with:
           config-required: 'true'
           require-version-state: 'true'

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   build:
-    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@v2.4.1
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@v2
     with:
       runner-preset: kungfu-v4-self-hosted
       publish-channel: ${{ startsWith(github.ref_name, 'publish-gate/alpha/') && 'alpha' || startsWith(github.ref_name, 'publish-gate/release/') && 'release' || 'major' }}
@@ -115,7 +115,7 @@ jobs:
           KF_NPM_EXPECTED_VERSION: ${{ fromJSON(needs.build.outputs.release-manifest-json).anchorManifest.summary.npmVersion }}
 
       - name: Promote release ref and publish npm package set
-        uses: kungfu-systems/buildchain/actions/promote-buildchain-ref@v2.4.1
+        uses: kungfu-systems/buildchain/actions/promote-buildchain-ref@v2
         env:
           KF_NPM_DIST_TAG: ${{ needs.build.outputs.publish-channel == 'alpha' && 'alpha' || 'latest' }}
           KF_NPM_EXPECTED_VERSION: ${{ fromJSON(needs.build.outputs.release-manifest-json).anchorManifest.summary.npmVersion }}

--- a/.github/workflows/release-verify.yaml
+++ b/.github/workflows/release-verify.yaml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   build:
-    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@v2.4.1
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@v2
     with:
       runner-preset: kungfu-v4-self-hosted
       setup-node: true

--- a/libnode.release.json
+++ b/libnode.release.json
@@ -4,5 +4,5 @@
   "nodeTag": "v22.22.3",
   "nodeCommit": "fdfa0ff0dbaf0fbf4d7d6d89a2ab807f3177fa5c",
   "libnodeRevision": 3,
-  "npmVersion": "22.22.3-kf.3-alpha.4"
+  "npmVersion": "22.22.3-kf.3-alpha.5"
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "name": "kungfu-trader",
     "email": "info@kungfu.link"
   },
-  "version": "22.22.3-kf.3-alpha.4",
+  "version": "22.22.3-kf.3-alpha.5",
   "description": "Build shared node lib",
   "license": "Apache-2.0",
   "main": "src/js/index.js",


### PR DESCRIPTION
Promote dev/v22/v22.22 to alpha/v22/v22.22 for @kungfu-tech/libnode 22.22.3-kf.3-alpha.5.\n\nThis channel PR carries the alpha.5 semver bump and switches libnode workflows to the floating stable buildchain @v2 tag so future stable buildchain upgrades do not require routine libnode workflow edits.\n\nExpected publish path after merge:\n- merge this reviewed PR into alpha/v22/v22.22\n- push publish-gate/alpha/v22/v22.22/22.22.3-kf.3-alpha.5 to the resulting alpha HEAD\n- let Buildchain trusted publishing publish the root and platform npm packages\n