### PR TITLE
release: publish libnode 22.22.3-kf.3-alpha.6

### DIFF
--- a/.gyp/node-platform-package.js
+++ b/.gyp/node-platform-package.js
@@ -126,7 +126,9 @@ function linkPackageAliases(packageDistDir, descriptor) {
 
     const target = path.join(packageDistDir, alias.target);
     fs.removeSync(target);
-    fs.symlinkSync(path.basename(source), target);
+    // npm pack drops symlink entries. A same-directory hardlink keeps the
+    // unversioned linker name in the tarball without duplicating the payload.
+    fs.linkSync(source, target);
   }
 }
 

--- a/.gyp/npm-publish-tarballs.js
+++ b/.gyp/npm-publish-tarballs.js
@@ -92,8 +92,13 @@ function listTarballDetails(file) {
     if (entryStart === -1) continue;
 
     let entry = line.slice(entryStart).trim();
-    const linkTarget = entry.indexOf(' -> ');
-    if (linkTarget !== -1) entry = entry.slice(0, linkTarget);
+    for (const separator of [' -> ', ' link to ']) {
+      const linkTarget = entry.indexOf(separator);
+      if (linkTarget !== -1) {
+        entry = entry.slice(0, linkTarget);
+        break;
+      }
+    }
     details.set(entry, { type: line[0] });
   }
   return details;
@@ -117,8 +122,13 @@ function verifyPlatformTarballPayload(pkg) {
     }
 
     const target = details.get(alias.target);
-    if (target && target.type !== 'l') {
-      throw new Error(`${packageKey(pkg)} must not package ${alias.target} as a full binary copy`);
+    if (!target) {
+      throw new Error(`${packageKey(pkg)} is missing required alias ${alias.target}`);
+    }
+    if (!['h', 'l'].includes(target.type)) {
+      throw new Error(
+        `${packageKey(pkg)} must package ${alias.target} as a hardlink or symlink alias, not a full binary copy`,
+      );
     }
   }
 

--- a/libnode.release.json
+++ b/libnode.release.json
@@ -4,5 +4,5 @@
   "nodeTag": "v22.22.3",
   "nodeCommit": "fdfa0ff0dbaf0fbf4d7d6d89a2ab807f3177fa5c",
   "libnodeRevision": 3,
-  "npmVersion": "22.22.3-kf.3-alpha.5"
+  "npmVersion": "22.22.3-kf.3-alpha.6"
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "name": "kungfu-trader",
     "email": "info@kungfu.link"
   },
-  "version": "22.22.3-kf.3-alpha.5",
+  "version": "22.22.3-kf.3-alpha.6",
   "description": "Build shared node lib",
   "license": "Apache-2.0",
   "main": "src/js/index.js",


### PR DESCRIPTION
## Summary\n- promote libnode alpha.6 from dev to alpha\n- includes hardlink alias packaging fix for darwin/linux platform tarballs\n\n## Verification\n- PR #39 Build passed on Linux x64, macOS ARM64, Windows x64\n- release path will run Buildchain strict channel verification before publish