### PR TITLE
build: materialize libnode aliases after install

### DIFF
--- a/.gyp/node-platform-package.js
+++ b/.gyp/node-platform-package.js
@@ -113,7 +113,7 @@ function verifyPlatformDist(descriptor) {
   };
 }
 
-function linkPackageAliases(packageDistDir, descriptor) {
+function ensurePackageAliasesAreMaterializable(packageDistDir, descriptor) {
   for (const alias of descriptor.aliases || []) {
     const source = listFiles(packageDistDir, alias.source)
       .filter((file) => path.basename(file) !== alias.target)
@@ -126,9 +126,9 @@ function linkPackageAliases(packageDistDir, descriptor) {
 
     const target = path.join(packageDistDir, alias.target);
     fs.removeSync(target);
-    // npm pack drops symlink entries. A same-directory hardlink keeps the
-    // unversioned linker name in the tarball without duplicating the payload.
-    fs.linkSync(source, target);
+    // npm pack drops symlink entries and the public npm registry rejects
+    // hardlinks. Platform packages therefore reconstruct aliases at install
+    // time via ensure-libnode-aliases.js instead of shipping link entries.
   }
 }
 
@@ -278,7 +278,7 @@ function preparePlatformPackage(descriptor) {
   fs.copySync(distDir, packageDistDir, {
     dereference: false,
   });
-  linkPackageAliases(packageDistDir, descriptor);
+  ensurePackageAliasesAreMaterializable(packageDistDir, descriptor);
   copyIfExists(path.join(rootDir, 'LICENSE'), path.join(packageRoot, 'LICENSE'));
   copyIfExists(path.join(rootDir, 'libnode.release.json'), path.join(packageRoot, 'libnode.release.json'));
   writePackageReadme(packageRoot, descriptor.name, `This package contains libnode binaries for ${descriptor.key}.`);

--- a/.gyp/npm-publish-tarballs.js
+++ b/.gyp/npm-publish-tarballs.js
@@ -110,6 +110,7 @@ function verifyPlatformTarballPayload(pkg) {
 
   const entries = listTarballEntries(pkg.file);
   const details = listTarballDetails(pkg.file);
+  const scripts = pkg.packageJson.scripts || {};
   for (const pattern of requirements.binaries) {
     if (!entries.some((entry) => pattern.test(entry))) {
       throw new Error(`${packageKey(pkg)} is missing required binary matching ${pattern}`);
@@ -121,13 +122,14 @@ function verifyPlatformTarballPayload(pkg) {
       throw new Error(`${packageKey(pkg)} is missing alias helper ${alias.helper}`);
     }
 
-    const target = details.get(alias.target);
-    if (!target) {
-      throw new Error(`${packageKey(pkg)} is missing required alias ${alias.target}`);
+    if (scripts.postinstall !== 'node ensure-libnode-aliases.js') {
+      throw new Error(`${packageKey(pkg)} must reconstruct libnode aliases from postinstall`);
     }
-    if (!['h', 'l'].includes(target.type)) {
+
+    const target = details.get(alias.target);
+    if (target) {
       throw new Error(
-        `${packageKey(pkg)} must package ${alias.target} as a hardlink or symlink alias, not a full binary copy`,
+        `${packageKey(pkg)} must not package ${alias.target}; npm install must materialize it from ${alias.helper}`,
       );
     }
   }
@@ -186,6 +188,7 @@ function packageFromTarball(file) {
     file,
     name,
     version,
+    packageJson,
     integrity: tarballIntegrity(file),
     main: name === mainPackageName,
     optionalDependencies: packageJson.optionalDependencies || {},

--- a/libnode.release.json
+++ b/libnode.release.json
@@ -4,5 +4,5 @@
   "nodeTag": "v22.22.3",
   "nodeCommit": "fdfa0ff0dbaf0fbf4d7d6d89a2ab807f3177fa5c",
   "libnodeRevision": 3,
-  "npmVersion": "22.22.3-kf.3-alpha.6"
+  "npmVersion": "22.22.3-kf.3-alpha.7"
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "name": "kungfu-trader",
     "email": "info@kungfu.link"
   },
-  "version": "22.22.3-kf.3-alpha.6",
+  "version": "22.22.3-kf.3-alpha.7",
   "description": "Build shared node lib",
   "license": "Apache-2.0",
   "main": "src/js/index.js",


### PR DESCRIPTION
## Summary
- switch platform alias handling from hardlinks to install-time materialization
- keep darwin/linux tarballs free of alias copies while requiring helper + postinstall
- bump alpha package version to 22.22.3-kf.3-alpha.7

## Validation
- corepack pnpm verify-release
- corepack pnpm verify-package-source
- node --check .gyp/node-platform-package.js
- node --check .gyp/npm-publish-tarballs.js
- git diff --check
- fake npm package-set validation via .gyp/npm-publish-tarballs.js