### PR TITLE
release: publish libnode 22.22.3-kf.3-alpha.9

### DIFF
--- a/libnode.release.json
+++ b/libnode.release.json
@@ -4,5 +4,5 @@
   "nodeTag": "v22.22.3",
   "nodeCommit": "fdfa0ff0dbaf0fbf4d7d6d89a2ab807f3177fa5c",
   "libnodeRevision": 3,
-  "npmVersion": "22.22.3-kf.3-alpha.8"
+  "npmVersion": "22.22.3-kf.3-alpha.9"
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "name": "kungfu-trader",
     "email": "info@kungfu.link"
   },
-  "version": "22.22.3-kf.3-alpha.8",
+  "version": "22.22.3-kf.3-alpha.9",
   "description": "Build shared node lib",
   "license": "Apache-2.0",
   "main": "src/js/index.js",


### PR DESCRIPTION
Promote dev/v22/v22.22 to alpha/v22/v22.22 for libnode 22.22.3-kf.3-alpha.9.

- Publish channel: alpha
- Expected npm version: 22.22.3-kf.3-alpha.9
- Buildchain runtime: @v2 stable

This should trigger the publish-gate source lock flow with one alpha build after merge.

Verification before PR:
- node .gyp/libnode-release-verify.js
- git diff --check
- corepack pnpm verify-package-source
- corepack pnpm pack --dry-run