### PR TITLE
release: publish libnode 22.22.3-kf.3-alpha.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,8 @@ jobs:
       artifact-name-template: '{artifact}-{platform}-{sha}'
       artifact-paths: |
         build/stage
+      release-candidate: ${{ startsWith(github.base_ref, 'alpha/') }}
+      publish-channel: ${{ startsWith(github.base_ref, 'alpha/') && 'alpha' || 'none' }}
       expected-artifacts-json: >-
         {"minFiles":1,"minTotalBytes":10000000}
       artifact-retention-days: 14

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -3,139 +3,36 @@ name: Release - New Version
 on:
   push:
     branches:
-      - publish-gate/alpha/**
-      - publish-gate/release/**
-      - publish-gate/major
+      - alpha/v*/v*.*
+      - release/v*/v*.*
 
 permissions:
-  contents: read
+  actions: read
+  contents: write
+  id-token: write
+  issues: write
 
 concurrency:
   group: libnode-release-new-version-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
-  build:
-    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@v2
+  promote:
+    uses: kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@v2
+    secrets: inherit
     with:
-      runner-preset: kungfu-v4-self-hosted
-      publish-channel: ${{ startsWith(github.ref_name, 'publish-gate/alpha/') && 'alpha' || startsWith(github.ref_name, 'publish-gate/release/') && 'release' || 'major' }}
-      publish-source-ref: ${{ github.ref_name }}
-      setup-node: true
-      node-version: '24'
-      install-command: node .gyp/buildchain-install.js "${{ vars.KF_NODE_GIT_URL }}" "${{ vars.KF_NODE_REFERENCE }}"
-      require-install: true
-      require-build: true
-      require-verify: true
+      package-manager: pnpm
       artifact-name: libnode
-      artifact-name-template: '{artifact}-{platform}-{sha}'
-      artifact-paths: |
-        build/stage
-      expected-artifacts-json: >-
-        {"minFiles":1,"minTotalBytes":10000000}
-      artifact-retention-days: 14
-
-  publish-transaction:
-    name: Publish npm package set through Buildchain
-    needs: [build]
-    if: ${{ needs.build.outputs.publish-allowed == 'true' }}
-    runs-on: ubuntu-24.04
-    permissions:
-      actions: read
-      contents: write
-      id-token: write
-    steps:
-      - name: Checkout promoted source
-        uses: actions/checkout@v7.0.0
-        with:
-          ref: ${{ needs.build.outputs.publish-source-sha }}
-          clean: true
-          persist-credentials: false
-
-      - name: Setup Node.js environment
-        uses: actions/setup-node@v6.4.0
-        with:
-          node-version: '24'
-          registry-url: 'https://registry.npmjs.org'
-
-      - name: Download build artifacts
-        uses: actions/download-artifact@v7.0.0
-        with:
-          path: github-artifacts
-
-      - name: Verify resolved release manifest
-        shell: bash
-        run: |
-          node - <<'NODE'
-          const manifest = JSON.parse(process.env.BUILDCHAIN_RELEASE_MANIFEST_JSON);
-          const channel = process.env.BUILDCHAIN_CHANNEL;
-          const sourceSha = process.env.BUILDCHAIN_SOURCE_SHA;
-          if (manifest.schema !== 1) throw new Error('release manifest schema must be 1');
-          if (manifest.sourceSha !== sourceSha) {
-            throw new Error(`manifest sourceSha ${manifest.sourceSha} != ${sourceSha}`);
-          }
-          if (!manifest.sourceLocked) {
-            throw new Error('release publication requires a publish-gate source lock');
-          }
-          if (!['alpha', 'release', 'major'].includes(manifest.channel)) {
-            throw new Error(`unsupported publish-gate channel: ${manifest.channel}`);
-          }
-          if ((manifest.channel === 'alpha' || manifest.channel === 'release') && !manifest.consumerVersion) {
-            throw new Error('publish-gate alpha/release source lock must include a consumer version');
-          }
-          const npmVersion = manifest.anchorManifest?.summary?.npmVersion;
-          if (!npmVersion) throw new Error('manifest anchor npmVersion is required');
-          const versionFile = (manifest.versionFiles || []).find((file) => file.path === 'package.json');
-          if (!versionFile || versionFile.version !== npmVersion) {
-            throw new Error(`package.json version ${versionFile?.version || '<missing>'} != anchor npmVersion ${npmVersion}`);
-          }
-          if (manifest.consumerVersion && manifest.consumerVersion !== npmVersion) {
-            throw new Error(`publish-gate consumer version ${manifest.consumerVersion} != anchor npmVersion ${npmVersion}`);
-          }
-          console.log(`manifest ok: ${channel} ${manifest.sourceRef} ${npmVersion} ${sourceSha}`);
-          NODE
-        env:
-          BUILDCHAIN_RELEASE_MANIFEST_JSON: ${{ needs.build.outputs.release-manifest-json }}
-          BUILDCHAIN_CHANNEL: ${{ needs.build.outputs.publish-channel }}
-          BUILDCHAIN_SOURCE_SHA: ${{ needs.build.outputs.publish-source-sha }}
-
-      - name: Prepare Buildchain publish evidence requirements
-        id: evidence
-        shell: bash
-        run: |
-          node .gyp/npm-publish-tarballs.js \
-            --write-buildchain-required-artifacts .buildchain/required-artifacts.json \
-            github-artifacts
-          {
-            echo 'required-artifacts-json<<JSON'
-            cat .buildchain/required-artifacts.json
-            echo 'JSON'
-          } >> "${GITHUB_OUTPUT}"
-        env:
-          KF_NPM_EXPECTED_VERSION: ${{ fromJSON(needs.build.outputs.release-manifest-json).anchorManifest.summary.npmVersion }}
-
-      - name: Promote release ref and publish npm package set
-        uses: kungfu-systems/buildchain/actions/promote-buildchain-ref@v2
-        env:
-          KF_NPM_DIST_TAG: ${{ needs.build.outputs.publish-channel == 'alpha' && 'alpha' || 'latest' }}
-          KF_NPM_EXPECTED_VERSION: ${{ fromJSON(needs.build.outputs.release-manifest-json).anchorManifest.summary.npmVersion }}
-        with:
-          token: ${{ secrets.BUILDCHAIN_PROMOTION_TOKEN || github.token }}
-          sha: ${{ needs.build.outputs.publish-source-sha }}
-          target-ref: ${{ needs.build.outputs.publish-source-channel == 'major' && 'publish-gate/major' || format('{0}/{1}', needs.build.outputs.publish-source-channel, needs.build.outputs.publish-source-line) }}
-          allow-repository: ${{ github.repository }}
-          require-governance: 'true'
-          require-version-state: 'true'
-          required-status-check: 'build'
-          publish-transaction: 'true'
-          release-passport-product-name: Libnode
-          publish-mode: publish-final-version
-          publish-auth: trusted-publishing
-          publish-dist-tag: ${{ needs.build.outputs.publish-channel == 'alpha' && 'alpha' || 'latest' }}
-          publish-package-set-order: platforms-first-main-last
-          publish-package-main: '@kungfu-tech/libnode'
-          require-publish-source-lock: 'true'
-          publish-source-ref: ${{ needs.build.outputs.publish-source-ref }}
-          publish-source-sha: ${{ needs.build.outputs.publish-source-sha }}
-          publish-source-locked: ${{ needs.build.outputs.publish-source-locked }}
-          publish-required-artifacts-json: ${{ steps.evidence.outputs.required-artifacts-json }}
+      release-candidate-workflow-file: ${{ startsWith(github.ref_name, 'release/') && 'release-verify.yaml' || 'build.yml' }}
+      release-candidate-workflow-name: ${{ startsWith(github.ref_name, 'release/') && 'Release - Verify' || 'Build' }}
+      artifact-patterns: |
+        libnode-darwin-arm64-*
+        libnode-linux-x64-*
+        libnode-win32-x64-*
+      required-status-check: build
+      required-artifact-count: 4
+      publish-mode: publish-final-version
+      publish-dist-tag: ${{ startsWith(github.ref_name, 'alpha/') && 'alpha' || 'latest' }}
+      publish-package-set-order: platforms-first-main-last
+      publish-package-main: '@kungfu-tech/libnode'
+      release-passport-product-name: Libnode

--- a/.github/workflows/release-verify.yaml
+++ b/.github/workflows/release-verify.yaml
@@ -29,6 +29,8 @@ jobs:
       artifact-name-template: '{artifact}-{platform}-{sha}'
       artifact-paths: |
         build/stage
+      release-candidate: true
+      publish-channel: release
       expected-artifacts-json: >-
         {"minFiles":1,"minTotalBytes":10000000}
       artifact-retention-days: 14

--- a/README.md
+++ b/README.md
@@ -32,15 +32,15 @@ node -p "require('@kungfu-tech/libnode').include"
 
 The `Build` and `Release - Verify` workflows run through Kungfu Buildchain and build the Node.js version pinned by `libnode.release.json` and `.gitmodules`. Each runner packages its native output as an npm platform tarball under `build/stage/npm`.
 
-Npm publication is handled only by Buildchain publish-gate promotion. Reviewed
-channel branches prepare release material; package publication enters through
-`publish-gate/alpha/<line>/<version>` for dist-tag `alpha` or
-`publish-gate/release/<line>/<version>` for dist-tag `latest`. The reusable
-Buildchain workflow locks that gate branch to an exact source SHA before build
-and publish, and the promotion action rejects publish side effects unless the
-same source-lock protocol is present. The exact npm version is read from
-`package.json` and `libnode.release.json`, and must match the publish-gate
-consumer version.
+Npm publication is handled by Buildchain release-candidate promotion. Reviewed
+channel PRs build the release candidate once and upload the platform package
+artifacts, build summary, and release-candidate passport. After the channel
+branch is updated, the reusable Buildchain promotion workflow reuses that
+PR-stage evidence, locks the matching `publish-gate/<channel>/<line>/<version>`
+ref to the channel commit, generates npm package-set requirements from the
+downloaded tarballs, and publishes through the configured dist-tag. The exact
+npm version is read from `package.json` and `libnode.release.json`; it is not
+passed by hand through the workflow.
 
 npm publication uses GitHub Trusted Publishing from the GitHub-hosted publish
 job. The workflow does not use `NPM_PUSH_TOKEN` or npm dist-tag recovery tokens

--- a/buildchain.toml
+++ b/buildchain.toml
@@ -74,4 +74,4 @@ commands = [
 
 [lifecycle.publish]
 timeout_minutes = 20
-command = "node .gyp/npm-publish-tarballs.js github-artifacts"
+command = "node .gyp/npm-publish-tarballs.js .buildchain/release-candidate/payloads"


### PR DESCRIPTION
Publish @kungfu-tech/libnode 22.22.3-kf.3-alpha.9 through the Buildchain v2 release-candidate promotion flow.\n\nThis PR includes the libnode-side migration to the stable Buildchain v2 release-candidate promote wrapper so the PR build produces the reusable release-candidate evidence and the alpha branch push promotes that evidence to npm without a second heavy build.\n\nExpected flow:\n- one alpha channel PR: dev/v22/v22.22 -> alpha/v22/v22.22\n- one three-platform Build workflow run\n- Release - New Version promote-only publish after merge\n\nVerified before opening:\n- corepack pnpm verify-package-source\n- git diff --check\n- npm official registry returns 404 for 22.22.3-kf.3-alpha.9 before publish\n