### PR TITLE
ci: align release candidate artifact patterns

### DIFF
--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -26,11 +26,11 @@ jobs:
       release-candidate-workflow-file: ${{ startsWith(github.ref_name, 'release/') && 'release-verify.yaml' || 'build.yml' }}
       release-candidate-workflow-name: ${{ startsWith(github.ref_name, 'release/') && 'Release - Verify' || 'Build' }}
       artifact-patterns: |
-        libnode-darwin-arm64-*
+        libnode-macos-arm64-*
         libnode-linux-x64-*
-        libnode-win32-x64-*
+        libnode-windows-x64-*
       required-status-check: build
-      required-artifact-count: 4
+      required-artifact-count: 3
       publish-mode: publish-final-version
       publish-dist-tag: ${{ startsWith(github.ref_name, 'alpha/') && 'alpha' || 'latest' }}
       publish-package-set-order: platforms-first-main-last


### PR DESCRIPTION
Fix the libnode-side Release - New Version declaration so Buildchain v2 release-candidate-promote can resolve the PR-stage payload artifacts produced by the Build workflow.\n\nProblem observed in Release - New Version run 28708019670 after PR #45 merged:\n- Buildchain resolver expected at least 4 PR-stage payload artifacts but found 1.\n- The PR Build run 28707537788 actually produced platform payload artifacts named libnode-macos-arm64-*, libnode-linux-x64-*, and libnode-windows-x64-*.\n- The libnode wrapper had declared npm/os names libnode-darwin-arm64-* and libnode-win32-x64-* and required 4 payload containers.\n\nThis PR aligns the wrapper with the Buildchain artifact names and the three-platform payload count.\n\nThis is an extra PR caused by the previous libnode declaration bug; the prior three-platform Build run was already successful but the old alpha-side workflow could not promote it.\n\nVerified locally:\n- actionlint .github/workflows/release-new-version.yml\n- YAML parse\n- git diff --check\n- offline pattern check against PR #45 artifact names matched 3 payload artifacts\n