### PR TITLE
ci: test buildchain rc promote allow repository

### DIFF
--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -21,6 +21,7 @@ jobs:
     uses: kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@v2
     secrets: inherit
     with:
+      buildchain-ref: train/v2/v2.5/rc-promote-allow-repository
       package-manager: pnpm
       artifact-name: libnode
       release-candidate-workflow-file: ${{ startsWith(github.ref_name, 'release/') && 'release-verify.yaml' || 'build.yml' }}


### PR DESCRIPTION
Temporarily route Release - New Version through Buildchain train ref train/v2/v2.5/rc-promote-allow-repository so we can verify the release-candidate-promote allow-repository fix against libnode.\n\nContext:\n- PR #46 fixed libnode artifact-pattern/count declaration.\n- Release - New Version run 28708787668 resolved PR-stage RC evidence successfully but failed in promote-buildchain-ref with: Ref promotion is limited to kungfu-systems/buildchain; got kungfu-systems/libnode.\n- The provided Buildchain train ref exposes allow-repository and defaults it to the caller repository.\n\nVerified locally:\n- actionlint .github/workflows/release-new-version.yml\n- YAML parse\n- git diff --check\n