### PR TITLE
ci: use stable buildchain v2 for release promotion

### DIFF
--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -21,7 +21,6 @@ jobs:
     uses: kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@v2
     secrets: inherit
     with:
-      buildchain-ref: train/v2/v2.5/rc-promote-allow-repository
       package-manager: pnpm
       artifact-name: libnode
       release-candidate-workflow-file: ${{ startsWith(github.ref_name, 'release/') && 'release-verify.yaml' || 'build.yml' }}


### PR DESCRIPTION
## Summary
- remove the temporary Buildchain train runtime override
- return release promotion to the stable floating Buildchain v2 wrapper

## Validation
- git diff --check
- verified release-new-version.yml no longer contains buildchain-ref/train override

## Release note
This PR is expected to trigger one Build PR-stage native matrix before alpha promotion.