### PR TITLE
ci: enable buildchain s3 relay for alpha publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 concurrency:
   group: libnode-build-${{ github.event.pull_request.number || github.ref }}
@@ -21,6 +22,7 @@ jobs:
     uses: kungfu-systems/buildchain/.github/workflows/.build.yml@v2
     with:
       runner-preset: kungfu-v4-self-hosted
+      artifact-transfer-mode: s3-to-github-artifacts
       setup-node: true
       node-version: '24'
       install-command: node .gyp/buildchain-install.js "${{ vars.KF_NODE_GIT_URL }}" "${{ vars.KF_NODE_REFERENCE }}"

--- a/.github/workflows/release-verify.yaml
+++ b/.github/workflows/release-verify.yaml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 concurrency:
   group: libnode-release-verify-${{ github.event.pull_request.number || github.ref }}
@@ -19,6 +20,7 @@ jobs:
     uses: kungfu-systems/buildchain/.github/workflows/.build.yml@v2
     with:
       runner-preset: kungfu-v4-self-hosted
+      artifact-transfer-mode: s3-to-github-artifacts
       setup-node: true
       node-version: '24'
       install-command: node .gyp/buildchain-install.js "${{ vars.KF_NODE_GIT_URL }}" "${{ vars.KF_NODE_REFERENCE }}"

--- a/libnode.release.json
+++ b/libnode.release.json
@@ -4,5 +4,5 @@
   "nodeTag": "v22.22.3",
   "nodeCommit": "fdfa0ff0dbaf0fbf4d7d6d89a2ab807f3177fa5c",
   "libnodeRevision": 3,
-  "npmVersion": "22.22.3-kf.3-alpha.9"
+  "npmVersion": "22.22.3-kf.3-alpha.10"
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "name": "kungfu-trader",
     "email": "info@kungfu.link"
   },
-  "version": "22.22.3-kf.3-alpha.9",
+  "version": "22.22.3-kf.3-alpha.10",
   "description": "Build shared node lib",
   "license": "Apache-2.0",
   "main": "src/js/index.js",


### PR DESCRIPTION
## Summary
- enable Buildchain S3 artifact relay for Build, Release - Verify, and Release - New Version
- bump alpha version to 22.22.3-kf.3-alpha.10 for the validation publish

## Validation
- ruby YAML parse for modified workflows
- jq parse for package.json and libnode.release.json
- corepack pnpm verify-release
- corepack pnpm verify-package-source
- git diff --check

After this PR build validates relay mode, publish-gate/alpha will publish the alpha package set through the same Buildchain S3 relay path.