### PR TITLE
release: publish libnode 22.22.3-kf.3-alpha.10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 concurrency:
   group: libnode-build-${{ github.event.pull_request.number || github.ref }}
@@ -21,6 +22,7 @@ jobs:
     uses: kungfu-systems/buildchain/.github/workflows/.build.yml@v2
     with:
       runner-preset: kungfu-v4-self-hosted
+      artifact-transfer-mode: s3-to-github-artifacts
       setup-node: true
       node-version: '24'
       install-command: node .gyp/buildchain-install.js "${{ vars.KF_NODE_GIT_URL }}" "${{ vars.KF_NODE_REFERENCE }}"

--- a/.github/workflows/release-verify.yaml
+++ b/.github/workflows/release-verify.yaml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 concurrency:
   group: libnode-release-verify-${{ github.event.pull_request.number || github.ref }}
@@ -19,6 +20,7 @@ jobs:
     uses: kungfu-systems/buildchain/.github/workflows/.build.yml@v2
     with:
       runner-preset: kungfu-v4-self-hosted
+      artifact-transfer-mode: s3-to-github-artifacts
       setup-node: true
       node-version: '24'
       install-command: node .gyp/buildchain-install.js "${{ vars.KF_NODE_GIT_URL }}" "${{ vars.KF_NODE_REFERENCE }}"

--- a/libnode.release.json
+++ b/libnode.release.json
@@ -4,5 +4,5 @@
   "nodeTag": "v22.22.3",
   "nodeCommit": "fdfa0ff0dbaf0fbf4d7d6d89a2ab807f3177fa5c",
   "libnodeRevision": 3,
-  "npmVersion": "22.22.3-kf.3-alpha.9"
+  "npmVersion": "22.22.3-kf.3-alpha.10"
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "name": "kungfu-trader",
     "email": "info@kungfu.link"
   },
-  "version": "22.22.3-kf.3-alpha.9",
+  "version": "22.22.3-kf.3-alpha.10",
   "description": "Build shared node lib",
   "license": "Apache-2.0",
   "main": "src/js/index.js",


### PR DESCRIPTION
## Summary
- promote dev/v22/v22.22 to alpha/v22/v22.22
- publish @kungfu-tech/libnode 22.22.3-kf.3-alpha.10
- validate Buildchain S3 artifact relay on the release-candidate build

## Expected Buildchain flow
- Build workflow runs with release-candidate=true for alpha base
- self-hosted platform jobs upload heavy payloads through S3 relay
- relay-artifacts jobs rehydrate normal GitHub artifacts
- merging this PR triggers Release - New Version promote/publish

## Prior validation
- PR #50 Build run 28740199617 passed Linux x64, macOS arm64, Windows x64 and all relay artifact jobs.