### PR TITLE
Enable GitHub Release evidence publication

### DIFF
--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -38,3 +38,4 @@ jobs:
       publish-package-set-order: platforms-first-main-last
       publish-package-main: '@kungfu-tech/libnode'
       release-passport-product-name: Libnode
+      github-release: true


### PR DESCRIPTION
Enable Buildchain's github-release output for libnode release promotion so release passport/evidence assets are published to the exact-tag GitHub Release.