### PR TITLE
ci: sync alpha promotion fixes into dev

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  build-matrix:
     uses: kungfu-systems/buildchain/.github/workflows/.build.yml@v2
     with:
       runner-preset: kungfu-v4-self-hosted
@@ -41,3 +41,16 @@ jobs:
       expected-artifacts-json: >-
         {"minFiles":1,"minTotalBytes":10000000}
       artifact-retention-days: 14
+
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    needs: build-matrix
+    if: always()
+    steps:
+      - name: Require build matrix success
+        run: |
+          if [ "${{ needs.build-matrix.result }}" != "success" ]; then
+            echo "::error::build matrix result was ${{ needs.build-matrix.result }}"
+            exit 1
+          fi

--- a/libnode.release.json
+++ b/libnode.release.json
@@ -4,5 +4,5 @@
   "nodeTag": "v22.22.3",
   "nodeCommit": "fdfa0ff0dbaf0fbf4d7d6d89a2ab807f3177fa5c",
   "libnodeRevision": 3,
-  "npmVersion": "22.22.3-kf.3-alpha.11"
+  "npmVersion": "22.22.3-kf.3-alpha.12"
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "name": "kungfu-trader",
     "email": "info@kungfu.link"
   },
-  "version": "22.22.3-kf.3-alpha.11",
+  "version": "22.22.3-kf.3-alpha.12",
   "description": "Build shared node lib",
   "license": "Apache-2.0",
   "main": "src/js/index.js",


### PR DESCRIPTION
Sync the current alpha promotion fixes back into dev and prepare the next alpha package version.\n\nThis branch is based on the current alpha tip, so merging it into dev records the alpha ancestry required for the next strict dev→alpha promotion.\n\nChanges:\n- add the aggregate Build workflow status check already validated on alpha candidate #57\n- bump npm version state from 22.22.3-kf.3-alpha.11 to 22.22.3-kf.3-alpha.12, because alpha.11 failed before npm publication\n\nLocal verification:\n- pnpm verify-release\n- pnpm verify-package-source\n