### PR TITLE
Release alpha 22.22.3-kf.3-alpha.12

### DIFF
--- a/libnode.release.json
+++ b/libnode.release.json
@@ -4,5 +4,5 @@
   "nodeTag": "v22.22.3",
   "nodeCommit": "fdfa0ff0dbaf0fbf4d7d6d89a2ab807f3177fa5c",
   "libnodeRevision": 3,
-  "npmVersion": "22.22.3-kf.3-alpha.11"
+  "npmVersion": "22.22.3-kf.3-alpha.12"
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "name": "kungfu-trader",
     "email": "info@kungfu.link"
   },
-  "version": "22.22.3-kf.3-alpha.11",
+  "version": "22.22.3-kf.3-alpha.12",
   "description": "Build shared node lib",
   "license": "Apache-2.0",
   "main": "src/js/index.js",


### PR DESCRIPTION
Promote dev/v22/v22.22 to alpha/v22/v22.22 for libnode 22.22.3-kf.3-alpha.12.\n\nThis is the strict Buildchain promotion path: same-repository dev→alpha PR, with dev already containing the current alpha base.\n\nExpected after merge:\n- Release - New Version uses the PR-stage release-candidate artifacts\n- npm publishes via trusted publishing with dist-tag alpha\n- GitHub Release evidence/passport is published by Buildchain\n