### PR TITLE
feat(release): add KFD passport gates for libnode alpha

### DIFF
--- a/.buildchain/kfd-1/libnode-contract-world.witness.json
+++ b/.buildchain/kfd-1/libnode-contract-world.witness.json
@@ -1,0 +1,106 @@
+{
+  "schemaVersion": 1,
+  "contract": "kungfu-buildchain-kfd-1-witness-set",
+  "id": "libnode-release-contract-world",
+  "standard": "kfd-1",
+  "source": {
+    "repo": "kungfu-systems/libnode",
+    "ref": "dev/v22/v22.22"
+  },
+  "contractWorld": {
+    "id": "libnode-release-contract",
+    "schemaId": "https://kfd.libkungfu.dev/schemas/kfd-1/contract-world.schema.json",
+    "digest": "sha256:8a8d0be7ebb79f41746ac6de03f3c7721cc3bdc73d6e68376d70b6759d7ff2b1"
+  },
+  "standardContract": {
+    "id": "libnode-release-contract",
+    "path": "libnode.release.json",
+    "sha256": "8a8d0be7ebb79f41746ac6de03f3c7721cc3bdc73d6e68376d70b6759d7ff2b1"
+  },
+  "selfHostingBoundary": {
+    "mode": "self-hosted-standard-contract",
+    "sourceScope": "Libnode release manifest, package metadata, package builder, KFD declarations, and Buildchain release workflow.",
+    "artifactScope": "Checked-out promotion source surfaces plus KFD-3 artifact witness over the npm package set.",
+    "boundary": "Buildchain verifies declared KFD-1 source surfaces byte-for-byte before release passport finalization.",
+    "residualRisk": []
+  },
+  "responsibility": {
+    "sourceContractOwner": "Libnode maintainers",
+    "artifactVerificationOwner": "Buildchain KFD-1 release gate",
+    "releasePassportProofOwner": "Buildchain"
+  },
+  "surfaces": [
+    {
+      "name": "package-manifest",
+      "sourcePath": "package.json",
+      "sourceSha256": "5e42f4d5403daf356d546aa725944ba1c8e57bd8bc71513035765b036ae0a6d1",
+      "artifactPath": "package.json",
+      "expectedSha256": "5e42f4d5403daf356d546aa725944ba1c8e57bd8bc71513035765b036ae0a6d1",
+      "byteForByte": true
+    },
+    {
+      "name": "release-manifest",
+      "sourcePath": "libnode.release.json",
+      "sourceSha256": "8a8d0be7ebb79f41746ac6de03f3c7721cc3bdc73d6e68376d70b6759d7ff2b1",
+      "artifactPath": "libnode.release.json",
+      "expectedSha256": "8a8d0be7ebb79f41746ac6de03f3c7721cc3bdc73d6e68376d70b6759d7ff2b1",
+      "byteForByte": true
+    },
+    {
+      "name": "buildchain-config",
+      "sourcePath": "buildchain.toml",
+      "sourceSha256": "1ccbc2dee94a30dff10b7596125340a985e8150febe74e7efe0b67f11299e972",
+      "artifactPath": "buildchain.toml",
+      "expectedSha256": "1ccbc2dee94a30dff10b7596125340a985e8150febe74e7efe0b67f11299e972",
+      "byteForByte": true
+    },
+    {
+      "name": "package-builder",
+      "sourcePath": ".gyp/node-platform-package.js",
+      "sourceSha256": "7871e2dc7240ebf69de06b4016c7715417d3273f3b0231b5f0459e5dd8b94bea",
+      "artifactPath": ".gyp/node-platform-package.js",
+      "expectedSha256": "7871e2dc7240ebf69de06b4016c7715417d3273f3b0231b5f0459e5dd8b94bea",
+      "byteForByte": true
+    },
+    {
+      "name": "release-verifier",
+      "sourcePath": ".gyp/libnode-release-verify.js",
+      "sourceSha256": "db0cffa624ef2a08d0fcd521f054da937768b1cec908ae8b229599c70ddfc7f0",
+      "artifactPath": ".gyp/libnode-release-verify.js",
+      "expectedSha256": "db0cffa624ef2a08d0fcd521f054da937768b1cec908ae8b229599c70ddfc7f0",
+      "byteForByte": true
+    },
+    {
+      "name": "kfd3-artifact-verifier",
+      "sourcePath": ".gyp/libnode-kfd3-artifact-verify.js",
+      "sourceSha256": "a6a15fe9a54b02dd2cc78a69300ad9af3fa7ce7c6bcab652e6c6049198ddc172",
+      "artifactPath": ".gyp/libnode-kfd3-artifact-verify.js",
+      "expectedSha256": "a6a15fe9a54b02dd2cc78a69300ad9af3fa7ce7c6bcab652e6c6049198ddc172",
+      "byteForByte": true
+    },
+    {
+      "name": "release-workflow",
+      "sourcePath": ".github/workflows/release-new-version.yml",
+      "sourceSha256": "52884dfe57dc34402e49a871fad64582ee8d86b3a6e8bc722325c14b4c20a7a8",
+      "artifactPath": ".github/workflows/release-new-version.yml",
+      "expectedSha256": "52884dfe57dc34402e49a871fad64582ee8d86b3a6e8bc722325c14b4c20a7a8",
+      "byteForByte": true
+    },
+    {
+      "name": "kfd3-collaboration-interface",
+      "sourcePath": ".buildchain/kfd-3/collaboration-interface.json",
+      "sourceSha256": "da72832c4fee28021f90381b86ed94ccf6d8bddcb23b80419d256e5a9e4bb653",
+      "artifactPath": ".buildchain/kfd-3/collaboration-interface.json",
+      "expectedSha256": "da72832c4fee28021f90381b86ed94ccf6d8bddcb23b80419d256e5a9e4bb653",
+      "byteForByte": true
+    },
+    {
+      "name": "kfd3-prebuild-witness",
+      "sourcePath": ".buildchain/kfd-3/collaboration-interface.prebuild.json",
+      "sourceSha256": "402fd994d3b7b3644a0d8ae0e5754a2072925cbf14858bfd6bded724706af39c",
+      "artifactPath": ".buildchain/kfd-3/collaboration-interface.prebuild.json",
+      "expectedSha256": "402fd994d3b7b3644a0d8ae0e5754a2072925cbf14858bfd6bded724706af39c",
+      "byteForByte": true
+    }
+  ]
+}

--- a/.buildchain/kfd-2/public-release-trust.claim.json
+++ b/.buildchain/kfd-2/public-release-trust.claim.json
@@ -1,0 +1,112 @@
+{
+  "id": "claim:libnode-public-release-trust",
+  "public": true,
+  "claim": "Libnode npm releases are anchored to libnode.release.json, built as a three-platform package set, verified by product-owned package gates, and published through Buildchain trusted publishing.",
+  "sourceBindings": [
+    {
+      "id": "release-manifest",
+      "path": "libnode.release.json"
+    },
+    {
+      "id": "package-manifest",
+      "path": "package.json"
+    },
+    {
+      "id": "buildchain-config",
+      "path": "buildchain.toml"
+    },
+    {
+      "id": "package-builder",
+      "path": ".gyp/node-platform-package.js"
+    },
+    {
+      "id": "release-workflow",
+      "path": ".github/workflows/release-new-version.yml"
+    }
+  ],
+  "machineEvidence": [
+    {
+      "id": "release-manifest-verifier",
+      "path": ".gyp/libnode-release-verify.js"
+    },
+    {
+      "id": "package-source-verifier",
+      "path": ".gyp/node-platform-package.js",
+      "command": "corepack pnpm verify-package-source"
+    },
+    {
+      "id": "kfd3-artifact-verifier",
+      "path": ".gyp/libnode-kfd3-artifact-verify.js",
+      "command": "node .gyp/libnode-kfd3-artifact-verify.js .buildchain/release-candidate/payloads"
+    }
+  ],
+  "hashes": {
+    "releaseContract": "libnode.release.json + package.json + buildchain.toml",
+    "releasePassport": "computed by Buildchain at promotion time",
+    "packageSet": "computed from npm tarball digests by the KFD-3 artifact verifier"
+  },
+  "artifacts": [
+    {
+      "name": "@kungfu-tech/libnode",
+      "kind": "npm-main-package"
+    },
+    {
+      "name": "@kungfu-tech/libnode-darwin-arm64",
+      "kind": "npm-platform-package"
+    },
+    {
+      "name": "@kungfu-tech/libnode-linux-x64",
+      "kind": "npm-platform-package"
+    },
+    {
+      "name": "@kungfu-tech/libnode-win32-x64",
+      "kind": "npm-platform-package"
+    }
+  ],
+  "verification": {
+    "result": "passed",
+    "gates": [
+      "corepack pnpm verify-release",
+      "corepack pnpm verify-package-source",
+      "Buildchain KFD-1 contract-world gate",
+      "Buildchain KFD-3 collaboration-interface reverse audit",
+      "npm trusted publishing transaction"
+    ]
+  },
+  "auditBoundary": {
+    "scope": "Libnode source manifest, package metadata, Buildchain release transaction, npm package set, and declared platform package surfaces.",
+    "outOfScope": [
+      "Upstream Node project governance",
+      "Bit-for-bit compiler reproducibility across host toolchains",
+      "Consumer operating-system dynamic loader behavior outside the packaged layout"
+    ]
+  },
+  "responsibility": {
+    "owner": "Libnode maintainers",
+    "sourceContractOwner": "Libnode maintainers",
+    "artifactVerificationOwner": "libnode package verifier",
+    "releasePassportProofOwner": "Buildchain"
+  },
+  "residualRisk": [
+    {
+      "id": "upstream-node-source-trust",
+      "definedBy": "https://kfd.libkungfu.dev/schemas/kfd-2/trust-taxonomy.schema.json#/$defs/residualRisk",
+      "riskType": "external-fact-risk",
+      "trustImpact": "downgrade-warning",
+      "machineProvability": "partially-machine-verifiable",
+      "agentAction": "verify-external-facts",
+      "reason": "The release gate verifies the declared Node tag and commit anchor, but upstream Node project trust is external to libnode.",
+      "owner": "Libnode maintainers"
+    },
+    {
+      "id": "native-toolchain-reproducibility",
+      "definedBy": "https://kfd.libkungfu.dev/schemas/kfd-2/trust-taxonomy.schema.json#/$defs/residualRisk",
+      "riskType": "partial-machine-coverage-risk",
+      "trustImpact": "downgrade-warning",
+      "machineProvability": "not-exhaustively-enumerable",
+      "agentAction": "accept-with-warning",
+      "reason": "The release gate verifies packaged bytes and layout, but does not claim bit-for-bit reproducibility across all compiler and SDK versions.",
+      "owner": "Libnode maintainers"
+    }
+  ]
+}

--- a/.buildchain/kfd-3/collaboration-interface.json
+++ b/.buildchain/kfd-3/collaboration-interface.json
@@ -1,0 +1,167 @@
+{
+  "schemaVersion": 1,
+  "contract": "kfd-3-collaboration-interface",
+  "product": {
+    "name": "Libnode",
+    "package": "@kungfu-tech/libnode",
+    "repository": "https://github.com/kungfu-systems/libnode"
+  },
+  "participants": [
+    {
+      "id": "package-consumer",
+      "kind": "human-or-agent"
+    },
+    {
+      "id": "native-build-consumer",
+      "kind": "human-or-agent"
+    },
+    {
+      "id": "release-maintainer",
+      "kind": "maintainer"
+    },
+    {
+      "id": "buildchain-release-system",
+      "kind": "automation"
+    }
+  ],
+  "surfaces": [
+    {
+      "id": "npm:main-package",
+      "name": "@kungfu-tech/libnode main package",
+      "kind": "package-entrypoint",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "package.json"
+    },
+    {
+      "id": "npm:platform-darwin-arm64",
+      "name": "@kungfu-tech/libnode-darwin-arm64 package",
+      "kind": "platform-package",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": ".gyp/node-platform-package.js"
+    },
+    {
+      "id": "npm:platform-linux-x64",
+      "name": "@kungfu-tech/libnode-linux-x64 package",
+      "kind": "platform-package",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": ".gyp/node-platform-package.js"
+    },
+    {
+      "id": "npm:platform-win32-x64",
+      "name": "@kungfu-tech/libnode-win32-x64 package",
+      "kind": "platform-package",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": ".gyp/node-platform-package.js"
+    },
+    {
+      "id": "layout:headers",
+      "name": "Node and Node-API headers in platform packages",
+      "kind": "native-header-layout",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": ".gyp/node-platform-package.js"
+    },
+    {
+      "id": "layout:darwin-libnode-alias-policy",
+      "name": "macOS libnode.dylib alias materialization policy",
+      "kind": "native-link-layout",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": ".gyp/node-platform-package.js"
+    },
+    {
+      "id": "layout:linux-libnode-alias-policy",
+      "name": "Linux libnode.so alias materialization policy",
+      "kind": "native-link-layout",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": ".gyp/node-platform-package.js"
+    },
+    {
+      "id": "layout:windows-import-library",
+      "name": "Windows libnode import library",
+      "kind": "native-link-layout",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": ".gyp/node-platform-package.js"
+    },
+    {
+      "id": "release:node-version-anchor",
+      "name": "Node upstream version and commit anchor",
+      "kind": "release-fact",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "libnode.release.json"
+    },
+    {
+      "id": "release:trusted-publishing",
+      "name": "npm trusted publishing release path",
+      "kind": "release-control",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": ".github/workflows/release-new-version.yml"
+    }
+  ],
+  "closure": {
+    "classificationMode": "closed-world",
+    "unclassifiedEntrypointsPolicy": "fail",
+    "nonExhaustivelyEnumerableSurfaces": []
+  },
+  "transparentConstraints": [
+    "The npm version is anchored to libnode.release.json npmVersion.",
+    "The upstream Node version is anchored to libnode.release.json nodeTag and nodeCommit.",
+    "The release package set is published platforms-first and main-last.",
+    "macOS arm64, Linux x64, and Windows x64 platform packages are public release surfaces.",
+    "macOS and Linux link aliases are materialized by package postinstall policy instead of npm tarball symlinks.",
+    "Windows packages must include both DLL and import library outputs."
+  ],
+  "choicePaths": [
+    {
+      "id": "consume-main-package",
+      "participants": ["package-consumer"],
+      "entrypoint": "npm install @kungfu-tech/libnode",
+      "expectedOutcome": "The main package resolves a matching platform package."
+    },
+    {
+      "id": "verify-release-passport",
+      "participants": ["package-consumer", "native-build-consumer", "release-maintainer"],
+      "entrypoint": "Buildchain release passport on the exact GitHub Release tag",
+      "expectedOutcome": "Consumers can inspect package-set evidence, trusted publishing evidence, and KFD gate results."
+    }
+  ],
+  "extensionRequests": [
+    {
+      "id": "libnode-release-surface-change",
+      "participants": ["package-consumer", "release-maintainer"],
+      "trigger": "A new public package, binary layout, or release verification surface is needed.",
+      "requestPath": {
+        "kind": "github-issue",
+        "target": "https://github.com/kungfu-systems/libnode"
+      }
+    }
+  ]
+}

--- a/.buildchain/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd-3/collaboration-interface.prebuild.json
@@ -1,0 +1,168 @@
+{
+  "schemaVersion": 1,
+  "contract": "kungfu-buildchain-kfd-3-collaboration-interface-prebuild-witness",
+  "id": "libnode-release-interface",
+  "standard": "kfd-3",
+  "supportLevel": "release",
+  "source": {
+    "repo": "kungfu-systems/libnode",
+    "ref": "dev/v22/v22.22"
+  },
+  "sourceRegistry": {
+    "id": "libnode-release-contract",
+    "path": "libnode.release.json",
+    "version": "22.22.3-kf.3-alpha.13"
+  },
+  "collaborationInterfaceDigest": "sha256:da72832c4fee28021f90381b86ed94ccf6d8bddcb23b80419d256e5a9e4bb653",
+  "collaborationInterface": {
+    "schemaVersion": 1,
+    "contract": "kfd-3-collaboration-interface",
+    "digest": "sha256:da72832c4fee28021f90381b86ed94ccf6d8bddcb23b80419d256e5a9e4bb653",
+    "product": {
+      "name": "Libnode",
+      "package": "@kungfu-tech/libnode",
+      "repository": "https://github.com/kungfu-systems/libnode"
+    },
+    "participants": [
+      {
+        "id": "package-consumer",
+        "kind": "human-or-agent"
+      },
+      {
+        "id": "native-build-consumer",
+        "kind": "human-or-agent"
+      },
+      {
+        "id": "release-maintainer",
+        "kind": "maintainer"
+      },
+      {
+        "id": "buildchain-release-system",
+        "kind": "automation"
+      }
+    ],
+    "surfaces": [
+      {
+        "id": "npm:main-package",
+        "name": "@kungfu-tech/libnode main package",
+        "kind": "package-entrypoint",
+        "availability": "shipped",
+        "visibility": "public",
+        "participantFacing": true,
+        "public": true,
+        "sourcePath": "package.json"
+      },
+      {
+        "id": "npm:platform-darwin-arm64",
+        "name": "@kungfu-tech/libnode-darwin-arm64 package",
+        "kind": "platform-package",
+        "availability": "shipped",
+        "visibility": "public",
+        "participantFacing": true,
+        "public": true,
+        "sourcePath": ".gyp/node-platform-package.js"
+      },
+      {
+        "id": "npm:platform-linux-x64",
+        "name": "@kungfu-tech/libnode-linux-x64 package",
+        "kind": "platform-package",
+        "availability": "shipped",
+        "visibility": "public",
+        "participantFacing": true,
+        "public": true,
+        "sourcePath": ".gyp/node-platform-package.js"
+      },
+      {
+        "id": "npm:platform-win32-x64",
+        "name": "@kungfu-tech/libnode-win32-x64 package",
+        "kind": "platform-package",
+        "availability": "shipped",
+        "visibility": "public",
+        "participantFacing": true,
+        "public": true,
+        "sourcePath": ".gyp/node-platform-package.js"
+      },
+      {
+        "id": "layout:headers",
+        "name": "Node and Node-API headers in platform packages",
+        "kind": "native-header-layout",
+        "availability": "shipped",
+        "visibility": "public",
+        "participantFacing": true,
+        "public": true,
+        "sourcePath": ".gyp/node-platform-package.js"
+      },
+      {
+        "id": "layout:darwin-libnode-alias-policy",
+        "name": "macOS libnode.dylib alias materialization policy",
+        "kind": "native-link-layout",
+        "availability": "shipped",
+        "visibility": "public",
+        "participantFacing": true,
+        "public": true,
+        "sourcePath": ".gyp/node-platform-package.js"
+      },
+      {
+        "id": "layout:linux-libnode-alias-policy",
+        "name": "Linux libnode.so alias materialization policy",
+        "kind": "native-link-layout",
+        "availability": "shipped",
+        "visibility": "public",
+        "participantFacing": true,
+        "public": true,
+        "sourcePath": ".gyp/node-platform-package.js"
+      },
+      {
+        "id": "layout:windows-import-library",
+        "name": "Windows libnode import library",
+        "kind": "native-link-layout",
+        "availability": "shipped",
+        "visibility": "public",
+        "participantFacing": true,
+        "public": true,
+        "sourcePath": ".gyp/node-platform-package.js"
+      },
+      {
+        "id": "release:node-version-anchor",
+        "name": "Node upstream version and commit anchor",
+        "kind": "release-fact",
+        "availability": "shipped",
+        "visibility": "public",
+        "participantFacing": true,
+        "public": true,
+        "sourcePath": "libnode.release.json"
+      },
+      {
+        "id": "release:trusted-publishing",
+        "name": "npm trusted publishing release path",
+        "kind": "release-control",
+        "availability": "shipped",
+        "visibility": "public",
+        "participantFacing": true,
+        "public": true,
+        "sourcePath": ".github/workflows/release-new-version.yml"
+      }
+    ],
+    "closure": {
+      "classificationMode": "closed-world",
+      "unclassifiedEntrypointsPolicy": "fail",
+      "nonExhaustivelyEnumerableSurfaces": []
+    }
+  },
+  "expectedArtifactVerification": {
+    "command": "node .gyp/libnode-kfd3-artifact-verify.js .buildchain/release-candidate/payloads"
+  },
+  "auditBoundary": {
+    "mode": "closed-world",
+    "scope": "participant-facing public libnode npm release surfaces",
+    "reachableSurfaceMode": "declared-boundary",
+    "unclassifiedPolicy": "fail",
+    "nonExhaustivelyEnumerableSurfaces": []
+  },
+  "residualRisk": [],
+  "responsibility": {
+    "registryFactsOwner": "Libnode maintainers",
+    "artifactVerificationOwner": "libnode package verifier",
+    "releasePassportProofOwner": "Buildchain"
+  }
+}

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -38,4 +38,8 @@ jobs:
       publish-package-set-order: platforms-first-main-last
       publish-package-main: '@kungfu-tech/libnode'
       release-passport-product-name: Libnode
+      release-passport-kfd-1-witness-jsons: .buildchain/kfd-1/libnode-contract-world.witness.json
+      release-passport-kfd-2-claim-jsons: .buildchain/kfd-2/public-release-trust.claim.json
+      release-passport-kfd-3-prebuild-witness-jsons: .buildchain/kfd-3/collaboration-interface.prebuild.json
+      release-passport-kfd-3-artifact-verify-command: node .gyp/libnode-kfd3-artifact-verify.js .buildchain/release-candidate/payloads
       github-release: true

--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,14 @@ __pypackages__/
 
 # Build related
 .buildchain/
+!.buildchain/
+.buildchain/*
+!.buildchain/kfd-1/
+!.buildchain/kfd-1/**
+!.buildchain/kfd-2/
+!.buildchain/kfd-2/**
+!.buildchain/kfd-3/
+!.buildchain/kfd-3/**
 github-artifacts/
 build/
 build-*/

--- a/.gyp/libnode-kfd3-artifact-verify.js
+++ b/.gyp/libnode-kfd3-artifact-verify.js
@@ -1,0 +1,252 @@
+const childProcess = require('child_process');
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..');
+const release = readJson(path.join(repoRoot, 'libnode.release.json'));
+const packageJson = readJson(path.join(repoRoot, 'package.json'));
+const interfacePath = path.join(repoRoot, '.buildchain', 'kfd-3', 'collaboration-interface.json');
+const payloadRoot = path.resolve(
+  repoRoot,
+  process.argv[2] || process.env.BUILDCHAIN_RELEASE_CANDIDATE_PAYLOADS || '.buildchain/release-candidate/payloads',
+);
+
+const packageNames = {
+  main: '@kungfu-tech/libnode',
+  darwin: '@kungfu-tech/libnode-darwin-arm64',
+  linux: '@kungfu-tech/libnode-linux-x64',
+  windows: '@kungfu-tech/libnode-win32-x64',
+};
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+function sha256File(file) {
+  return crypto.createHash('sha256').update(fs.readFileSync(file)).digest('hex');
+}
+
+function sha256Text(text) {
+  return crypto.createHash('sha256').update(text).digest('hex');
+}
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function listFiles(root) {
+  if (!fs.existsSync(root)) return [];
+  return fs.readdirSync(root, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = path.join(root, entry.name);
+    if (entry.isDirectory()) return listFiles(entryPath);
+    return entry.isFile() ? [entryPath] : [];
+  });
+}
+
+function packageFileName(name, version) {
+  return `${name.replace(/^@/, '').replace('/', '-')}-${version}.tgz`;
+}
+
+function findPackageTarball(name) {
+  const expected = packageFileName(name, release.npmVersion);
+  const matches = listFiles(payloadRoot).filter((file) => path.basename(file) === expected);
+  if (matches.length !== 1) {
+    fail(
+      `Expected exactly one ${name} tarball named ${expected} under ${path.relative(repoRoot, payloadRoot) || payloadRoot}; found ${matches.length}`,
+    );
+  }
+  return matches[0];
+}
+
+function listTarball(file) {
+  const result = childProcess.spawnSync('tar', ['-tzf', file], {
+    encoding: 'utf8',
+    windowsHide: true,
+  });
+  if (result.status !== 0) {
+    fail(`Unable to inspect ${path.basename(file)}: ${result.stderr || result.stdout || `exit ${result.status}`}`);
+  }
+  return result.stdout.split(/\r?\n/).filter(Boolean);
+}
+
+function requireEntry(entries, label, predicate) {
+  if (!entries.some(predicate)) {
+    fail(`Missing ${label}`);
+  }
+}
+
+function verifyMainPackage(file) {
+  const entries = listTarball(file);
+  requireEntry(entries, 'main package runtime entrypoint', (entry) => entry === 'package/src/js/index.js');
+  requireEntry(entries, 'main package release manifest', (entry) => entry === 'package/libnode.release.json');
+  return entries;
+}
+
+function verifyDarwinPackage(file) {
+  const entries = listTarball(file);
+  requireEntry(entries, 'darwin versioned libnode dylib', (entry) =>
+    /^package\/dist\/node\/libnode\.\d+\.dylib$/.test(entry),
+  );
+  requireEntry(entries, 'darwin alias materializer', (entry) => entry === 'package/ensure-libnode-aliases.js');
+  requireEntry(entries, 'darwin node.h', (entry) => entry === 'package/dist/node/include/node.h');
+  requireEntry(entries, 'darwin node_api.h', (entry) => entry === 'package/dist/node/include/node_api.h');
+  return entries;
+}
+
+function verifyLinuxPackage(file) {
+  const entries = listTarball(file);
+  requireEntry(entries, 'linux versioned libnode so', (entry) => /^package\/dist\/node\/libnode\.so\.\d+$/.test(entry));
+  requireEntry(entries, 'linux alias materializer', (entry) => entry === 'package/ensure-libnode-aliases.js');
+  requireEntry(entries, 'linux node.h', (entry) => entry === 'package/dist/node/include/node.h');
+  requireEntry(entries, 'linux node_api.h', (entry) => entry === 'package/dist/node/include/node_api.h');
+  return entries;
+}
+
+function verifyWindowsPackage(file) {
+  const entries = listTarball(file);
+  requireEntry(entries, 'windows libnode dll', (entry) => /^package\/dist\/node\/libnode.*\.dll$/i.test(entry));
+  requireEntry(entries, 'windows import library', (entry) => /^package\/dist\/node\/libnode.*\.lib$/i.test(entry));
+  requireEntry(entries, 'windows node.h', (entry) => entry === 'package/dist/node/include/node.h');
+  requireEntry(entries, 'windows node_api.h', (entry) => entry === 'package/dist/node/include/node_api.h');
+  return entries;
+}
+
+function surface(id, name, kind, sourcePath) {
+  return {
+    id,
+    name,
+    kind,
+    availability: 'shipped',
+    visibility: 'public',
+    participantFacing: true,
+    public: true,
+    sourcePath,
+  };
+}
+
+function main() {
+  if (packageJson.version !== release.npmVersion) {
+    fail(
+      `package.json version ${packageJson.version} does not match libnode.release.json npmVersion ${release.npmVersion}`,
+    );
+  }
+
+  const files = {
+    main: findPackageTarball(packageNames.main),
+    darwin: findPackageTarball(packageNames.darwin),
+    linux: findPackageTarball(packageNames.linux),
+    windows: findPackageTarball(packageNames.windows),
+  };
+
+  verifyMainPackage(files.main);
+  verifyDarwinPackage(files.darwin);
+  verifyLinuxPackage(files.linux);
+  verifyWindowsPackage(files.windows);
+
+  const digests = Object.fromEntries(Object.entries(files).map(([key, file]) => [key, `sha256:${sha256File(file)}`]));
+  const interfaceDigest = `sha256:${sha256File(interfacePath)}`;
+  const packageSetDigest = `sha256:${sha256Text(JSON.stringify(digests, Object.keys(digests).sort()))}`;
+
+  const witness = {
+    schemaVersion: 1,
+    contract: 'kungfu-buildchain-kfd-3-collaboration-interface-artifact-witness',
+    id: 'libnode-release-interface',
+    standard: 'kfd-3',
+    sourceRegistry: {
+      id: 'libnode-release-contract',
+      path: 'libnode.release.json',
+      version: release.npmVersion,
+      digest: `sha256:${sha256File(path.join(repoRoot, 'libnode.release.json'))}`,
+    },
+    collaborationInterface: {
+      digest: interfaceDigest,
+    },
+    artifact: {
+      name: '@kungfu-tech/libnode npm package set',
+      path: path.relative(repoRoot, payloadRoot).split(path.sep).join('/'),
+      digest: packageSetDigest,
+      packages: Object.fromEntries(
+        Object.entries(files).map(([key, file]) => [
+          key,
+          {
+            name: packageNames[key],
+            file: path.relative(payloadRoot, file).split(path.sep).join('/'),
+            digest: digests[key],
+          },
+        ]),
+      ),
+    },
+    exposedSurfaces: [
+      surface('npm:main-package', '@kungfu-tech/libnode main package', 'package-entrypoint', 'package.json'),
+      surface(
+        'npm:platform-darwin-arm64',
+        '@kungfu-tech/libnode-darwin-arm64 package',
+        'platform-package',
+        '.gyp/node-platform-package.js',
+      ),
+      surface(
+        'npm:platform-linux-x64',
+        '@kungfu-tech/libnode-linux-x64 package',
+        'platform-package',
+        '.gyp/node-platform-package.js',
+      ),
+      surface(
+        'npm:platform-win32-x64',
+        '@kungfu-tech/libnode-win32-x64 package',
+        'platform-package',
+        '.gyp/node-platform-package.js',
+      ),
+      surface(
+        'layout:headers',
+        'Node and Node-API headers in platform packages',
+        'native-header-layout',
+        '.gyp/node-platform-package.js',
+      ),
+      surface(
+        'layout:darwin-libnode-alias-policy',
+        'macOS libnode.dylib alias materialization policy',
+        'native-link-layout',
+        '.gyp/node-platform-package.js',
+      ),
+      surface(
+        'layout:linux-libnode-alias-policy',
+        'Linux libnode.so alias materialization policy',
+        'native-link-layout',
+        '.gyp/node-platform-package.js',
+      ),
+      surface(
+        'layout:windows-import-library',
+        'Windows libnode import library',
+        'native-link-layout',
+        '.gyp/node-platform-package.js',
+      ),
+      surface(
+        'release:node-version-anchor',
+        'Node upstream version and commit anchor',
+        'release-fact',
+        'libnode.release.json',
+      ),
+      surface(
+        'release:trusted-publishing',
+        'npm trusted publishing release path',
+        'release-control',
+        '.github/workflows/release-new-version.yml',
+      ),
+    ],
+    verifier: {
+      name: 'libnode KFD-3 artifact verifier',
+      command: 'node .gyp/libnode-kfd3-artifact-verify.js',
+      result: 'passed',
+    },
+  };
+
+  process.stdout.write(`${JSON.stringify(witness, null, 2)}\n`);
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error.message);
+  process.exit(1);
+}

--- a/libnode.release.json
+++ b/libnode.release.json
@@ -4,5 +4,5 @@
   "nodeTag": "v22.22.3",
   "nodeCommit": "fdfa0ff0dbaf0fbf4d7d6d89a2ab807f3177fa5c",
   "libnodeRevision": 3,
-  "npmVersion": "22.22.3-kf.3-alpha.12"
+  "npmVersion": "22.22.3-kf.3-alpha.13"
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "name": "kungfu-trader",
     "email": "info@kungfu.link"
   },
-  "version": "22.22.3-kf.3-alpha.12",
+  "version": "22.22.3-kf.3-alpha.13",
   "description": "Build shared node lib",
   "license": "Apache-2.0",
   "main": "src/js/index.js",
@@ -36,6 +36,7 @@
     "prepare-node-source": "node .gyp/node-source-prepare.js",
     "rebuild": "node .gyp/node-build.js rebuild",
     "verify-release": "node .gyp/libnode-release-verify.js",
+    "verify-kfd3-artifact": "node .gyp/libnode-kfd3-artifact-verify.js",
     "verify-package-source": "node .gyp/node-platform-package.js verify-source",
     "format": "prettier --write --parser typescript .gyp/*.js src/js/*.js"
   },


### PR DESCRIPTION
## Summary
- add KFD-1 contract-world witness for libnode release facts
- add KFD-2 public release trust claim with explicit residual risks
- add KFD-3 collaboration-interface prebuild witness and artifact verifier
- wire Buildchain release passport KFD inputs and bump alpha to 22.22.3-kf.3-alpha.13

## Verification
- corepack pnpm verify-release
- corepack pnpm verify-package-source
- git diff --check
- local Buildchain release passport simulation with KFD-1/2/3 inputs

## Notes
- KFD-2 intentionally reports downgraded warning for upstream Node and native toolchain residual risk; KFD-1 and KFD-3 hard gates pass in simulation.