### PR TITLE
ci(release): allow promote workflow check updates

### DIFF
--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   actions: read
+  checks: write
   contents: write
   id-token: write
   issues: write


### PR DESCRIPTION
Fix the Release - New Version caller permissions for Buildchain v2 promotion.

Buildchain's reusable release-candidate promote workflow requests checks: write. The libnode caller workflow only granted actions/contents/id-token/issues, so GitHub rejected the alpha publish run at startup before any job/log was created.

This PR only grants checks: write to the caller workflow; it does not change package payload files or the libnode version.