### PR TITLE
release(alpha): publish 22.22.3-kf.3-alpha.13

### DIFF
--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   actions: read
+  checks: write
   contents: write
   id-token: write
   issues: write


### PR DESCRIPTION
Promote dev/v22/v22.22 to alpha/v22/v22.22 after fixing the Release - New Version caller permissions required by Buildchain v2 promotion.

This is still @kungfu-tech/libnode 22.22.3-kf.3-alpha.13. The extra PR/build is caused by the previous alpha push failing at GitHub workflow startup because the caller workflow lacked checks: write for the Buildchain promote reusable workflow.