### PR TITLE
ci(release): refresh KFD workflow witness hash

### DIFF
--- a/.buildchain/kfd-1/libnode-contract-world.witness.json
+++ b/.buildchain/kfd-1/libnode-contract-world.witness.json
@@ -81,9 +81,9 @@
     {
       "name": "release-workflow",
       "sourcePath": ".github/workflows/release-new-version.yml",
-      "sourceSha256": "52884dfe57dc34402e49a871fad64582ee8d86b3a6e8bc722325c14b4c20a7a8",
+      "sourceSha256": "14aad9f50a6f7bc96a5c14927e97fc00ed7cca31e8eab11a2542e39ac716fa89",
       "artifactPath": ".github/workflows/release-new-version.yml",
-      "expectedSha256": "52884dfe57dc34402e49a871fad64582ee8d86b3a6e8bc722325c14b4c20a7a8",
+      "expectedSha256": "14aad9f50a6f7bc96a5c14927e97fc00ed7cca31e8eab11a2542e39ac716fa89",
       "byteForByte": true
     },
     {


### PR DESCRIPTION
Refresh the KFD-1 release-workflow surface digest after adding checks: write to Release - New Version.

The previous alpha promote reached KFD-1 finalization and failed because the release workflow byte-for-byte digest in .buildchain/kfd-1/libnode-contract-world.witness.json still pointed at the pre-permission-fix workflow content.

This PR only updates the KFD-1 witness hash; it does not change package payload files or the libnode version.