### PR TITLE
release(alpha): publish 22.22.3-kf.3-alpha.13

### DIFF
--- a/.buildchain/kfd-1/libnode-contract-world.witness.json
+++ b/.buildchain/kfd-1/libnode-contract-world.witness.json
@@ -81,9 +81,9 @@
     {
       "name": "release-workflow",
       "sourcePath": ".github/workflows/release-new-version.yml",
-      "sourceSha256": "52884dfe57dc34402e49a871fad64582ee8d86b3a6e8bc722325c14b4c20a7a8",
+      "sourceSha256": "14aad9f50a6f7bc96a5c14927e97fc00ed7cca31e8eab11a2542e39ac716fa89",
       "artifactPath": ".github/workflows/release-new-version.yml",
-      "expectedSha256": "52884dfe57dc34402e49a871fad64582ee8d86b3a6e8bc722325c14b4c20a7a8",
+      "expectedSha256": "14aad9f50a6f7bc96a5c14927e97fc00ed7cca31e8eab11a2542e39ac716fa89",
       "byteForByte": true
     },
     {


### PR DESCRIPTION
Promote dev/v22/v22.22 to alpha/v22/v22.22 after refreshing the KFD-1 release-workflow witness hash.

This is still @kungfu-tech/libnode 22.22.3-kf.3-alpha.13. The previous promote reached KFD-1 finalization and failed because the release workflow digest in the KFD-1 witness still pointed at the pre-checks-permission workflow content.