### PR TITLE
chore(release): bump libnode alpha to 14

### DIFF
--- a/.buildchain/kfd-1/libnode-contract-world.witness.json
+++ b/.buildchain/kfd-1/libnode-contract-world.witness.json
@@ -10,12 +10,12 @@
   "contractWorld": {
     "id": "libnode-release-contract",
     "schemaId": "https://kfd.libkungfu.dev/schemas/kfd-1/contract-world.schema.json",
-    "digest": "sha256:8a8d0be7ebb79f41746ac6de03f3c7721cc3bdc73d6e68376d70b6759d7ff2b1"
+    "digest": "sha256:e07b53986f76d8a3af0ec58b6c7abbc2b6a94261e2da0004280f0a143cf0c3a0"
   },
   "standardContract": {
     "id": "libnode-release-contract",
     "path": "libnode.release.json",
-    "sha256": "8a8d0be7ebb79f41746ac6de03f3c7721cc3bdc73d6e68376d70b6759d7ff2b1"
+    "sha256": "e07b53986f76d8a3af0ec58b6c7abbc2b6a94261e2da0004280f0a143cf0c3a0"
   },
   "selfHostingBoundary": {
     "mode": "self-hosted-standard-contract",
@@ -33,17 +33,17 @@
     {
       "name": "package-manifest",
       "sourcePath": "package.json",
-      "sourceSha256": "5e42f4d5403daf356d546aa725944ba1c8e57bd8bc71513035765b036ae0a6d1",
+      "sourceSha256": "9092f881f572b36c7bddda388a4bcd6c11b366e56405616715fb58bafe7173bf",
       "artifactPath": "package.json",
-      "expectedSha256": "5e42f4d5403daf356d546aa725944ba1c8e57bd8bc71513035765b036ae0a6d1",
+      "expectedSha256": "9092f881f572b36c7bddda388a4bcd6c11b366e56405616715fb58bafe7173bf",
       "byteForByte": true
     },
     {
       "name": "release-manifest",
       "sourcePath": "libnode.release.json",
-      "sourceSha256": "8a8d0be7ebb79f41746ac6de03f3c7721cc3bdc73d6e68376d70b6759d7ff2b1",
+      "sourceSha256": "e07b53986f76d8a3af0ec58b6c7abbc2b6a94261e2da0004280f0a143cf0c3a0",
       "artifactPath": "libnode.release.json",
-      "expectedSha256": "8a8d0be7ebb79f41746ac6de03f3c7721cc3bdc73d6e68376d70b6759d7ff2b1",
+      "expectedSha256": "e07b53986f76d8a3af0ec58b6c7abbc2b6a94261e2da0004280f0a143cf0c3a0",
       "byteForByte": true
     },
     {
@@ -97,9 +97,9 @@
     {
       "name": "kfd3-prebuild-witness",
       "sourcePath": ".buildchain/kfd-3/collaboration-interface.prebuild.json",
-      "sourceSha256": "402fd994d3b7b3644a0d8ae0e5754a2072925cbf14858bfd6bded724706af39c",
+      "sourceSha256": "b6fe7ab725271e6a478550338b2c749fd848ca48b0536ab3ebbd10728a382812",
       "artifactPath": ".buildchain/kfd-3/collaboration-interface.prebuild.json",
-      "expectedSha256": "402fd994d3b7b3644a0d8ae0e5754a2072925cbf14858bfd6bded724706af39c",
+      "expectedSha256": "b6fe7ab725271e6a478550338b2c749fd848ca48b0536ab3ebbd10728a382812",
       "byteForByte": true
     }
   ]

--- a/.buildchain/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd-3/collaboration-interface.prebuild.json
@@ -11,7 +11,7 @@
   "sourceRegistry": {
     "id": "libnode-release-contract",
     "path": "libnode.release.json",
-    "version": "22.22.3-kf.3-alpha.13"
+    "version": "22.22.3-kf.3-alpha.14"
   },
   "collaborationInterfaceDigest": "sha256:da72832c4fee28021f90381b86ed94ccf6d8bddcb23b80419d256e5a9e4bb653",
   "collaborationInterface": {

--- a/libnode.release.json
+++ b/libnode.release.json
@@ -4,5 +4,5 @@
   "nodeTag": "v22.22.3",
   "nodeCommit": "fdfa0ff0dbaf0fbf4d7d6d89a2ab807f3177fa5c",
   "libnodeRevision": 3,
-  "npmVersion": "22.22.3-kf.3-alpha.13"
+  "npmVersion": "22.22.3-kf.3-alpha.14"
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "name": "kungfu-trader",
     "email": "info@kungfu.link"
   },
-  "version": "22.22.3-kf.3-alpha.13",
+  "version": "22.22.3-kf.3-alpha.14",
   "description": "Build shared node lib",
   "license": "Apache-2.0",
   "main": "src/js/index.js",


### PR DESCRIPTION
Bump @kungfu-tech/libnode to 22.22.3-kf.3-alpha.14 after the alpha.13 promote partially published npm packages but failed before GitHub Release/passport finalization due to release transaction identity mismatch.

This updates:
- package.json version
- libnode.release.json npmVersion
- KFD-3 prebuild sourceRegistry version
- KFD-1 source surface hashes for package/release/prebuild witness

Local checks:
- corepack pnpm verify-release
- JSON parse for KFD declarations
- KFD-1 source hash consistency check