### PR TITLE
chore(release): publish libnode 22.22.3-kf.3-alpha.17

### DIFF
--- a/.buildchain/kfd-1/libnode-contract-world.witness.json
+++ b/.buildchain/kfd-1/libnode-contract-world.witness.json
@@ -10,12 +10,12 @@
   "contractWorld": {
     "id": "libnode-release-contract",
     "schemaId": "https://kfd.libkungfu.dev/schemas/kfd-1/contract-world.schema.json",
-    "digest": "sha256:90555ff4f2b127ecfe552feec55782175e3c227bbb46c400603eee13ff7e6920"
+    "digest": "sha256:acbdf650a621b6c059d423c9338093dc78cf88e5fa24a91ce844b6e151f0dd2b"
   },
   "standardContract": {
     "id": "libnode-release-contract",
     "path": "libnode.release.json",
-    "sha256": "90555ff4f2b127ecfe552feec55782175e3c227bbb46c400603eee13ff7e6920"
+    "sha256": "acbdf650a621b6c059d423c9338093dc78cf88e5fa24a91ce844b6e151f0dd2b"
   },
   "selfHostingBoundary": {
     "mode": "self-hosted-standard-contract",
@@ -33,17 +33,17 @@
     {
       "name": "package-manifest",
       "sourcePath": "package.json",
-      "sourceSha256": "d4ebd9d10839ad724f84df7f2772c1d090d9f021a8d69e3b533256e725f7301b",
+      "sourceSha256": "3fd9381ecd354445c4ad5af47f8678d97700b99acba6aea20fb1fdb3475f47c0",
       "artifactPath": "package.json",
-      "expectedSha256": "d4ebd9d10839ad724f84df7f2772c1d090d9f021a8d69e3b533256e725f7301b",
+      "expectedSha256": "3fd9381ecd354445c4ad5af47f8678d97700b99acba6aea20fb1fdb3475f47c0",
       "byteForByte": true
     },
     {
       "name": "release-manifest",
       "sourcePath": "libnode.release.json",
-      "sourceSha256": "90555ff4f2b127ecfe552feec55782175e3c227bbb46c400603eee13ff7e6920",
+      "sourceSha256": "acbdf650a621b6c059d423c9338093dc78cf88e5fa24a91ce844b6e151f0dd2b",
       "artifactPath": "libnode.release.json",
-      "expectedSha256": "90555ff4f2b127ecfe552feec55782175e3c227bbb46c400603eee13ff7e6920",
+      "expectedSha256": "acbdf650a621b6c059d423c9338093dc78cf88e5fa24a91ce844b6e151f0dd2b",
       "byteForByte": true
     },
     {
@@ -97,9 +97,9 @@
     {
       "name": "kfd3-prebuild-witness",
       "sourcePath": ".buildchain/kfd-3/collaboration-interface.prebuild.json",
-      "sourceSha256": "b53358e77cac8769faf23cc9f33932eee4db2dafc7c780acde9e698ed99f64de",
+      "sourceSha256": "7302a6d549a668db6f61d1172400aa87c00b7cf6a71263213d5125a73b1461ec",
       "artifactPath": ".buildchain/kfd-3/collaboration-interface.prebuild.json",
-      "expectedSha256": "b53358e77cac8769faf23cc9f33932eee4db2dafc7c780acde9e698ed99f64de",
+      "expectedSha256": "7302a6d549a668db6f61d1172400aa87c00b7cf6a71263213d5125a73b1461ec",
       "byteForByte": true
     }
   ]

--- a/.buildchain/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd-3/collaboration-interface.prebuild.json
@@ -11,7 +11,7 @@
   "sourceRegistry": {
     "id": "libnode-release-contract",
     "path": "libnode.release.json",
-    "version": "22.22.3-kf.3-alpha.16"
+    "version": "22.22.3-kf.3-alpha.17"
   },
   "collaborationInterfaceDigest": "sha256:da72832c4fee28021f90381b86ed94ccf6d8bddcb23b80419d256e5a9e4bb653",
   "collaborationInterface": {

--- a/buildchain.contract-lock.json
+++ b/buildchain.contract-lock.json
@@ -3,13 +3,13 @@
   "contract": "kungfu-buildchain-contract-lock",
   "buildchain": {
     "ref": "v2",
-    "resolvedSha": "09694eed5ba1b2bcfd85fd7b805d42ea2fc9b72a",
+    "resolvedSha": "c84b191c68d0309cc6d0b3fa4d61ab704c4b63e8",
     "contract": "kungfu-buildchain-runtime-contract-world",
-    "contractDigest": "sha256:6b6cd5aab74bde21e88bf2a551557280954fa9fcacc298b875b56bbd9e1e04db",
-    "compatibilityDigest": "sha256:407d6d5ee6a96a34d2cc30db9ac64cf4b1819ab6d77bd7a57a07a124f22101ca",
+    "contractDigest": "sha256:5a30e9e625f2643c30c0cda4a7825f336f616a39e356166aa32233fd2328c343",
+    "compatibilityDigest": "sha256:967df7e854fdf582294ddfb6403eff25c00db9518a24051e7d47cbd75527c785",
     "majorLine": "v2",
     "compatibilityPolicy": "major-compatible",
-    "acceptedAt": "2026-07-08T00:00:00.000Z",
+    "acceptedAt": "2026-07-09T00:00:00.000+08:00",
     "surfaces": [
       {
         "id": "reusable-build",
@@ -29,7 +29,7 @@
       {
         "id": "promote-buildchain-ref-action",
         "kind": "action",
-        "breakingDigest": "sha256:347b65aecd38bc671d8f697eabd15254f905b6f745389d7b26d7595a904a720c"
+        "breakingDigest": "sha256:0c5896590c8c9a44dfecbe060bcef1b43d3a9556737309dbe7e5f2bf83bfee6c"
       },
       {
         "id": "report-buildchain-issue-action",

--- a/libnode.release.json
+++ b/libnode.release.json
@@ -4,5 +4,5 @@
   "nodeTag": "v22.22.3",
   "nodeCommit": "fdfa0ff0dbaf0fbf4d7d6d89a2ab807f3177fa5c",
   "libnodeRevision": 3,
-  "npmVersion": "22.22.3-kf.3-alpha.16"
+  "npmVersion": "22.22.3-kf.3-alpha.17"
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "name": "kungfu-trader",
     "email": "info@kungfu.link"
   },
-  "version": "22.22.3-kf.3-alpha.16",
+  "version": "22.22.3-kf.3-alpha.17",
   "description": "Build shared node lib",
   "license": "Apache-2.0",
   "main": "src/js/index.js",


### PR DESCRIPTION
Publish libnode alpha 17 through the Buildchain v2 publish gate.

- Bumps package.json and libnode.release.json to 22.22.3-kf.3-alpha.17
- Uses the stable Buildchain @v2 workflows already declared in the repository
- Expects the PR-stage Build workflow to produce the release-candidate artifacts before promotion
