### PR TITLE
chore(release): publish libnode 22.22.3-kf.3-alpha.18

### DIFF
--- a/.buildchain/kfd-1/libnode-contract-world.witness.json
+++ b/.buildchain/kfd-1/libnode-contract-world.witness.json
@@ -10,12 +10,12 @@
   "contractWorld": {
     "id": "libnode-release-contract",
     "schemaId": "https://kfd.libkungfu.dev/schemas/kfd-1/contract-world.schema.json",
-    "digest": "sha256:acbdf650a621b6c059d423c9338093dc78cf88e5fa24a91ce844b6e151f0dd2b"
+    "digest": "sha256:42294c5890f69c94057b53d289c3df84db63168f81d9d01313f178965c56fa32"
   },
   "standardContract": {
     "id": "libnode-release-contract",
     "path": "libnode.release.json",
-    "sha256": "acbdf650a621b6c059d423c9338093dc78cf88e5fa24a91ce844b6e151f0dd2b"
+    "sha256": "42294c5890f69c94057b53d289c3df84db63168f81d9d01313f178965c56fa32"
   },
   "selfHostingBoundary": {
     "mode": "self-hosted-standard-contract",
@@ -33,17 +33,17 @@
     {
       "name": "package-manifest",
       "sourcePath": "package.json",
-      "sourceSha256": "3fd9381ecd354445c4ad5af47f8678d97700b99acba6aea20fb1fdb3475f47c0",
+      "sourceSha256": "999102f631995d076382853b7b7a96f28ff4c96bed5f6eb36c948ffa74ed5ddf",
       "artifactPath": "package.json",
-      "expectedSha256": "3fd9381ecd354445c4ad5af47f8678d97700b99acba6aea20fb1fdb3475f47c0",
+      "expectedSha256": "999102f631995d076382853b7b7a96f28ff4c96bed5f6eb36c948ffa74ed5ddf",
       "byteForByte": true
     },
     {
       "name": "release-manifest",
       "sourcePath": "libnode.release.json",
-      "sourceSha256": "acbdf650a621b6c059d423c9338093dc78cf88e5fa24a91ce844b6e151f0dd2b",
+      "sourceSha256": "42294c5890f69c94057b53d289c3df84db63168f81d9d01313f178965c56fa32",
       "artifactPath": "libnode.release.json",
-      "expectedSha256": "acbdf650a621b6c059d423c9338093dc78cf88e5fa24a91ce844b6e151f0dd2b",
+      "expectedSha256": "42294c5890f69c94057b53d289c3df84db63168f81d9d01313f178965c56fa32",
       "byteForByte": true
     },
     {
@@ -97,9 +97,9 @@
     {
       "name": "kfd3-prebuild-witness",
       "sourcePath": ".buildchain/kfd-3/collaboration-interface.prebuild.json",
-      "sourceSha256": "7302a6d549a668db6f61d1172400aa87c00b7cf6a71263213d5125a73b1461ec",
+      "sourceSha256": "396b1ccdfaf1571f6479004943a06ddcab9d6fc5791fbf5e514142b189423d5f",
       "artifactPath": ".buildchain/kfd-3/collaboration-interface.prebuild.json",
-      "expectedSha256": "7302a6d549a668db6f61d1172400aa87c00b7cf6a71263213d5125a73b1461ec",
+      "expectedSha256": "396b1ccdfaf1571f6479004943a06ddcab9d6fc5791fbf5e514142b189423d5f",
       "byteForByte": true
     }
   ]

--- a/.buildchain/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd-3/collaboration-interface.prebuild.json
@@ -11,7 +11,7 @@
   "sourceRegistry": {
     "id": "libnode-release-contract",
     "path": "libnode.release.json",
-    "version": "22.22.3-kf.3-alpha.17"
+    "version": "22.22.3-kf.3-alpha.18"
   },
   "collaborationInterfaceDigest": "sha256:da72832c4fee28021f90381b86ed94ccf6d8bddcb23b80419d256e5a9e4bb653",
   "collaborationInterface": {

--- a/buildchain.contract-lock.json
+++ b/buildchain.contract-lock.json
@@ -3,13 +3,13 @@
   "contract": "kungfu-buildchain-contract-lock",
   "buildchain": {
     "ref": "v2",
-    "resolvedSha": "c84b191c68d0309cc6d0b3fa4d61ab704c4b63e8",
+    "resolvedSha": "6fb9a4abebe2056163346a3692df42a926643635",
     "contract": "kungfu-buildchain-runtime-contract-world",
-    "contractDigest": "sha256:5a30e9e625f2643c30c0cda4a7825f336f616a39e356166aa32233fd2328c343",
+    "contractDigest": "sha256:3ed710d73ac54819396ec372044ec633230fac360b8cad972b4318044d782538",
     "compatibilityDigest": "sha256:967df7e854fdf582294ddfb6403eff25c00db9518a24051e7d47cbd75527c785",
     "majorLine": "v2",
     "compatibilityPolicy": "major-compatible",
-    "acceptedAt": "2026-07-09T00:00:00.000+08:00",
+    "acceptedAt": "2026-07-09T09:40:24+08:00",
     "surfaces": [
       {
         "id": "reusable-build",

--- a/libnode.release.json
+++ b/libnode.release.json
@@ -4,5 +4,5 @@
   "nodeTag": "v22.22.3",
   "nodeCommit": "fdfa0ff0dbaf0fbf4d7d6d89a2ab807f3177fa5c",
   "libnodeRevision": 3,
-  "npmVersion": "22.22.3-kf.3-alpha.17"
+  "npmVersion": "22.22.3-kf.3-alpha.18"
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "name": "kungfu-trader",
     "email": "info@kungfu.link"
   },
-  "version": "22.22.3-kf.3-alpha.17",
+  "version": "22.22.3-kf.3-alpha.18",
   "description": "Build shared node lib",
   "license": "Apache-2.0",
   "main": "src/js/index.js",


### PR DESCRIPTION
## Summary
- bump libnode alpha to 22.22.3-kf.3-alpha.18
- update Buildchain v2 contract lock to v2.10.10
- refresh KFD witnesses for the new release manifest

## Verification
- node .gyp/libnode-release-verify.js
- git diff --check
- corepack pnpm verify-release
- corepack pnpm verify-package-source
- corepack pnpm verify-kfd-witnesses
- Buildchain v2.10.10 contract lock check: unchanged

## Purpose
Validate Buildchain v2.10.10 public package release tag / GitHub Release / release passport fix after alpha.17 published to npm but failed release finalization.