### PR TITLE
fix(ci): adopt Buildchain dual-channel routing

### DIFF
--- a/.buildchain/kfd-1/libnode-contract-world.witness.json
+++ b/.buildchain/kfd-1/libnode-contract-world.witness.json
@@ -81,9 +81,9 @@
     {
       "name": "release-workflow",
       "sourcePath": ".github/workflows/release-new-version.yml",
-      "sourceSha256": "14aad9f50a6f7bc96a5c14927e97fc00ed7cca31e8eab11a2542e39ac716fa89",
+      "sourceSha256": "e60427b32d5ffde8813ff41e8fe0781a2fac2f9338709abd450de4e8372c902e",
       "artifactPath": ".github/workflows/release-new-version.yml",
-      "expectedSha256": "14aad9f50a6f7bc96a5c14927e97fc00ed7cca31e8eab11a2542e39ac716fa89",
+      "expectedSha256": "e60427b32d5ffde8813ff41e8fe0781a2fac2f9338709abd450de4e8372c902e",
       "byteForByte": true
     },
     {

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,10 +20,11 @@ concurrency:
 
 jobs:
   build-matrix:
-    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@v2
+    uses: kungfu-systems/buildchain/.github/workflows/build.yml@v2
     with:
       runner-preset: kungfu-v4-self-hosted
-      buildchain-contract-lock-path: buildchain.contract-lock.json
+      buildchain-alpha-contract-lock-path: buildchain.alpha-contract-lock.json
+      buildchain-stable-contract-lock-path: buildchain.contract-lock.json
       buildchain-contract-drift-issue-mode: compatible-and-breaking
       artifact-transfer-mode: s3-to-github-artifacts
       checkout-cache-mode: auto

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -23,7 +23,8 @@ jobs:
     secrets: inherit
     with:
       package-manager: pnpm
-      buildchain-contract-lock-path: buildchain.contract-lock.json
+      buildchain-ref: ${{ startsWith(github.ref_name, 'alpha/') && 'v2-alpha' || 'v2' }}
+      buildchain-contract-lock-path: ${{ startsWith(github.ref_name, 'alpha/') && 'buildchain.alpha-contract-lock.json' || 'buildchain.contract-lock.json' }}
       buildchain-contract-drift-issue-mode: compatible-and-breaking
       artifact-name: libnode
       release-candidate-workflow-file: ${{ startsWith(github.ref_name, 'release/') && 'release-verify.yaml' || 'build.yml' }}

--- a/.github/workflows/release-verify.yaml
+++ b/.github/workflows/release-verify.yaml
@@ -18,10 +18,11 @@ concurrency:
 
 jobs:
   build:
-    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@v2
+    uses: kungfu-systems/buildchain/.github/workflows/build.yml@v2
     with:
       runner-preset: kungfu-v4-self-hosted
-      buildchain-contract-lock-path: buildchain.contract-lock.json
+      buildchain-alpha-contract-lock-path: buildchain.alpha-contract-lock.json
+      buildchain-stable-contract-lock-path: buildchain.contract-lock.json
       buildchain-contract-drift-issue-mode: compatible-and-breaking
       artifact-transfer-mode: s3-to-github-artifacts
       checkout-cache-mode: auto

--- a/buildchain.alpha-contract-lock.json
+++ b/buildchain.alpha-contract-lock.json
@@ -2,10 +2,10 @@
   "schemaVersion": 1,
   "contract": "kungfu-buildchain-contract-lock",
   "buildchain": {
-    "ref": "v2",
-    "resolvedSha": "03ec04b384f6ce8d4bc2d569bc2642d91fa56906",
+    "ref": "v2-alpha",
+    "resolvedSha": "4cba0848b4dfa5381f3ed9d2256b174fb0fb8502",
     "contract": "kungfu-buildchain-runtime-contract-world",
-    "contractDigest": "sha256:7baa8a5044e49fea61abba63ef5f7fa3c582cf2c8cde50dd1395d1b1de2f3184",
+    "contractDigest": "sha256:46cccc23015847e18fcc1a88efce2c1b5c10c332551a12fa75ab14d8b70bf1c1",
     "compatibilityDigest": "sha256:2090784977bc7d54fc647215ef73532b9db26147a0b40ec3f56c31d611d806cc",
     "majorLine": "v2",
     "compatibilityPolicy": "major-compatible",


### PR DESCRIPTION
## Summary

- adopt the current Buildchain v2 dual-channel model
- route development/alpha validation through `v2-alpha` and release consumption through `v2`
- add and verify channel-specific consumer contract locks
- update repository checks and machine-readable evidence where applicable

## Validation

- `actionlint` on changed GitHub workflows
- stable and alpha contract locks regenerated and revalidated against exact v2.12 contract worlds
- repository-local lightweight checks passed where available
