### PR TITLE
fix(ci): make release promotion retryable

### DIFF
--- a/.buildchain/kfd-1/libnode-contract-world.witness.json
+++ b/.buildchain/kfd-1/libnode-contract-world.witness.json
@@ -81,9 +81,9 @@
     {
       "name": "release-workflow",
       "sourcePath": ".github/workflows/release-new-version.yml",
-      "sourceSha256": "4063c96e5e5234a36a42ad6f397da6bd83017aed21340a7585e387ad58403151",
+      "sourceSha256": "5a5187fbcfa881ac921afc7823c4b8b191465eb1499286e94f1b0a98f99b13e0",
       "artifactPath": ".github/workflows/release-new-version.yml",
-      "expectedSha256": "4063c96e5e5234a36a42ad6f397da6bd83017aed21340a7585e387ad58403151",
+      "expectedSha256": "5a5187fbcfa881ac921afc7823c4b8b191465eb1499286e94f1b0a98f99b13e0",
       "byteForByte": true
     },
     {

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - alpha/v*/v*.*
       - release/v*/v*.*
+  workflow_dispatch:
 
 permissions:
   actions: read

--- a/buildchain.alpha-contract-lock.json
+++ b/buildchain.alpha-contract-lock.json
@@ -3,13 +3,13 @@
   "contract": "kungfu-buildchain-contract-lock",
   "buildchain": {
     "ref": "v2-alpha",
-    "resolvedSha": "e48d41f381eb53edf0c14a63f9e110688237c58c",
+    "resolvedSha": "e1faf45d361fa80d8769860bcca0905b7591c4fe",
     "contract": "kungfu-buildchain-runtime-contract-world",
-    "contractDigest": "sha256:a178386e638d48ae66de156c48320e72e4f0c9931c094686a29b2c5dc0c15de9",
+    "contractDigest": "sha256:5ee3923ae7dc5e6633b0ef0be62a4f28611946f5333bb28c9c8229e88c149599",
     "compatibilityDigest": "sha256:edc3653e5cb34efd97065a6941db16140bbf375a565bbcf329d9d795bb07676f",
     "majorLine": "v2",
     "compatibilityPolicy": "major-compatible",
-    "acceptedAt": "2026-07-19T00:01:37.000Z",
+    "acceptedAt": "2026-07-19T01:11:24.000Z",
     "surfaces": [
       {
         "id": "reusable-build",


### PR DESCRIPTION
## Summary
- add an explicit workflow_dispatch entry to the single release promotion declaration
- accept the published Buildchain v2.14.3-alpha.2 runtime contract
- refresh the KFD-1 workflow byte witness

## Why
GitHub does not allow rerunning an invalid-workflow run with zero jobs. A first-class dispatch trigger lets maintainers retry promotion at the exact alpha/release ref without a dummy source change, while the normal branch push remains automatic.

## Validation
- libnode KFD witnesses
- libnode release contract
- package source verification
- actionlint
- Buildchain alpha contract lock: unchanged, compatible=true, drift=false
- exactly one Buildchain promotion declaration

Signed-off-by: Keren Dong <keren.dong@kungfu.link>