### PR TITLE
fix(ci): declare sealed publication admission

### DIFF
--- a/.buildchain/kfd-1/libnode-contract-world.witness.json
+++ b/.buildchain/kfd-1/libnode-contract-world.witness.json
@@ -81,9 +81,9 @@
     {
       "name": "release-workflow",
       "sourcePath": ".github/workflows/release-new-version.yml",
-      "sourceSha256": "5a5187fbcfa881ac921afc7823c4b8b191465eb1499286e94f1b0a98f99b13e0",
+      "sourceSha256": "a7bc52b1c868edda17499f204ab43f8b9bc5a74daf25c2f0eb2b08fbf859e1d2",
       "artifactPath": ".github/workflows/release-new-version.yml",
-      "expectedSha256": "5a5187fbcfa881ac921afc7823c4b8b191465eb1499286e94f1b0a98f99b13e0",
+      "expectedSha256": "a7bc52b1c868edda17499f204ab43f8b9bc5a74daf25c2f0eb2b08fbf859e1d2",
       "byteForByte": true
     },
     {

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -41,6 +41,12 @@ jobs:
       publish-dist-tag: ${{ startsWith(github.ref_name, 'alpha/') && 'alpha' || 'latest' }}
       publish-package-set-order: platforms-first-main-last
       publish-package-main: '@kungfu-tech/libnode'
+      publication-auto-admission: true
+      publication-auto-no-gate: true
+      publication-publisher-workflow-path: .github/workflows/release-new-version.yml
+      publication-product: Libnode
+      publication-target: npm:@kungfu-tech/libnode
+      publication-package-name: '@kungfu-tech/libnode'
       release-passport-product-name: Libnode
       release-passport-kfd-1-witness-jsons: .buildchain/kfd-1/libnode-contract-world.witness.json
       release-passport-kfd-2-claim-jsons: .buildchain/kfd-2/public-release-trust.claim.json


### PR DESCRIPTION
## Summary

- enable Buildchain-managed sealed publication admission for libnode
- explicitly declare that libnode has no separate consumer Shifu Gate registry
- bind publisher workflow, npm target, product, and package identity
- refresh the KFD-1 byte-for-byte workflow witness

This advances the updated #1387 validation target after promotion run 29671823329 correctly denied missing sealed evidence before artifact download and OIDC.

## Validation

- `pnpm run verify-kfd-witnesses`
- `pnpm run verify-release`
- `pnpm exec prettier --check .github/workflows/release-new-version.yml`
- `git diff --check`

Signed-off-by: Keren Dong <keren.dong@kungfu.link>