### PR TITLE
chore(release): admit sealed libnode alpha publication

### DIFF
--- a/.buildchain/kfd-1/libnode-contract-world.witness.json
+++ b/.buildchain/kfd-1/libnode-contract-world.witness.json
@@ -81,9 +81,9 @@
     {
       "name": "release-workflow",
       "sourcePath": ".github/workflows/release-new-version.yml",
-      "sourceSha256": "5a5187fbcfa881ac921afc7823c4b8b191465eb1499286e94f1b0a98f99b13e0",
+      "sourceSha256": "a7bc52b1c868edda17499f204ab43f8b9bc5a74daf25c2f0eb2b08fbf859e1d2",
       "artifactPath": ".github/workflows/release-new-version.yml",
-      "expectedSha256": "5a5187fbcfa881ac921afc7823c4b8b191465eb1499286e94f1b0a98f99b13e0",
+      "expectedSha256": "a7bc52b1c868edda17499f204ab43f8b9bc5a74daf25c2f0eb2b08fbf859e1d2",
       "byteForByte": true
     },
     {

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -41,6 +41,12 @@ jobs:
       publish-dist-tag: ${{ startsWith(github.ref_name, 'alpha/') && 'alpha' || 'latest' }}
       publish-package-set-order: platforms-first-main-last
       publish-package-main: '@kungfu-tech/libnode'
+      publication-auto-admission: true
+      publication-auto-no-gate: true
+      publication-publisher-workflow-path: .github/workflows/release-new-version.yml
+      publication-product: Libnode
+      publication-target: npm:@kungfu-tech/libnode
+      publication-package-name: '@kungfu-tech/libnode'
       release-passport-product-name: Libnode
       release-passport-kfd-1-witness-jsons: .buildchain/kfd-1/libnode-contract-world.witness.json
       release-passport-kfd-2-claim-jsons: .buildchain/kfd-2/public-release-trust.claim.json


### PR DESCRIPTION
Promote the reviewed sealed-publication declaration to the protected alpha channel.

- implementation: #99
- new three-platform candidate will be built and qualified on this channel PR
- post-merge publication must reuse that exact candidate with no native rebuild

Signed-off-by: Keren Dong <keren.dong@kungfu.link>