### PR TITLE
chore(buildchain): accept v2.14.3 channel contracts

### DIFF
--- a/buildchain.alpha-contract-lock.json
+++ b/buildchain.alpha-contract-lock.json
@@ -3,13 +3,13 @@
   "contract": "kungfu-buildchain-contract-lock",
   "buildchain": {
     "ref": "v2-alpha",
-    "resolvedSha": "8270576a1a37d3d8464a10ddeff5c9da450cc22e",
+    "resolvedSha": "701cca28a5bf9fe6dcf49c26097572bbe5f39a8b",
     "contract": "kungfu-buildchain-runtime-contract-world",
-    "contractDigest": "sha256:81c7c3721fa796b8d4585b0d8495822e405dd1e68b3a31db55934d4bf5687997",
+    "contractDigest": "sha256:01282a8e51767f52f821295b2258b0f8ef67525ba30c2973f9309645088bc70e",
     "compatibilityDigest": "sha256:edc3653e5cb34efd97065a6941db16140bbf375a565bbcf329d9d795bb07676f",
     "majorLine": "v2",
     "compatibilityPolicy": "major-compatible",
-    "acceptedAt": "2026-07-19T05:28:32.451Z",
+    "acceptedAt": "2026-07-19T14:20:41.000Z",
     "surfaces": [
       {
         "id": "reusable-build",

--- a/buildchain.contract-lock.json
+++ b/buildchain.contract-lock.json
@@ -3,13 +3,13 @@
   "contract": "kungfu-buildchain-contract-lock",
   "buildchain": {
     "ref": "v2",
-    "resolvedSha": "c95f9fc36b0ac8fb4ff6400189850c4ae683f3ea",
+    "resolvedSha": "565354f7b8abdbd68576468c04bfbcfc57d267e2",
     "contract": "kungfu-buildchain-runtime-contract-world",
-    "contractDigest": "sha256:90466f4b69982ad1aba65d22596baa4cd0112454f44b1f7c33ab3de017029a06",
-    "compatibilityDigest": "sha256:af162b86ab4506e9b5f1d3c59b41f3fd57fbad79ff4d749a7f12ff16460517f8",
+    "contractDigest": "sha256:53d4d8d89dbccb802e95c3b0b3bef2c857fccff136fc419cd70c6fb450c516dd",
+    "compatibilityDigest": "sha256:edc3653e5cb34efd97065a6941db16140bbf375a565bbcf329d9d795bb07676f",
     "majorLine": "v2",
     "compatibilityPolicy": "major-compatible",
-    "acceptedAt": "2026-07-18T15:27:29.000Z",
+    "acceptedAt": "2026-07-19T14:37:49.000Z",
     "surfaces": [
       {
         "id": "reusable-build",
@@ -24,7 +24,12 @@
       {
         "id": "release-candidate-promote",
         "kind": "workflow",
-        "breakingDigest": "sha256:6dbae32ce3d7aab3be6957065105af574794581847b7637314dad45f5349c919"
+        "breakingDigest": "sha256:1f476fb9a4854b362c4b24cef89a3c7675d7d63baf3bc828d7b8ae7d2787cead"
+      },
+      {
+        "id": "advanced-release-candidate-promote",
+        "kind": "workflow",
+        "breakingDigest": "sha256:aa30f22e3af0a89841310bdbdc900844dd95a66974db173fa140a71bbd7e82c0"
       },
       {
         "id": "web-surface",
@@ -124,7 +129,7 @@
       {
         "id": "controller:release-candidate-promotion",
         "kind": "controller",
-        "breakingDigest": "sha256:46238f8fc3c20924decc57ecad142a462fc4739c6bc21409d5cd2457fc1c3cdd"
+        "breakingDigest": "sha256:015d8de793adbd4c539416be7d7512e18cc92097e629b0203fa06d2c183e98bd"
       },
       {
         "id": "controller:release-propagation",


### PR DESCRIPTION
## Summary

- accept the published Buildchain `v2.14.3` stable runtime at `565354f7b8abdbd68576468c04bfbcfc57d267e2`
- accept `v2.14.3-alpha.9` on the alpha channel at `701cca28a5bf9fe6dcf49c26097572bbe5f39a8b`, resolving #107
- record the new advanced release-candidate promotion surface and updated controller digests
- preserve the existing `pnpm@11.9.0` consumer contract

## Evidence

- local stable contract check: compatible=true, drift=false
- local alpha contract check: compatible=true, drift=false
- stable and alpha promotion planner/validator blobs are byte-identical at the accepted revisions
- Buildchain alpha self-dogfood, exact-candidate fixture, libnode canary, and stable sealed promotion all passed
- local pnpm install used the package/noop path and did not rebuild native sources

Closes #107

Signed-off-by: Keren Dong <dongkeren@gmail.com>