### PR TITLE
chore(release): publish libnode alpha 20

### DIFF
--- a/.buildchain/kfd-1/libnode-contract-world.witness.json
+++ b/.buildchain/kfd-1/libnode-contract-world.witness.json
@@ -10,12 +10,12 @@
   "contractWorld": {
     "id": "libnode-release-contract",
     "schemaId": "https://kfd.libkungfu.dev/schemas/kfd-1/contract-world.schema.json",
-    "digest": "sha256:4c32420d0e3f323df92d0fdae612356ab44d4400daf586428f2370e069f82675"
+    "digest": "sha256:d2a4e4ff763402dee6fb2c571f397a07b760f9d770064bf2943708c0da65ec8d"
   },
   "standardContract": {
     "id": "libnode-release-contract",
     "path": "libnode.release.json",
-    "sha256": "4c32420d0e3f323df92d0fdae612356ab44d4400daf586428f2370e069f82675"
+    "sha256": "d2a4e4ff763402dee6fb2c571f397a07b760f9d770064bf2943708c0da65ec8d"
   },
   "selfHostingBoundary": {
     "mode": "self-hosted-standard-contract",
@@ -33,17 +33,17 @@
     {
       "name": "package-manifest",
       "sourcePath": "package.json",
-      "sourceSha256": "72c18243bc9007a32089e0880e51f4553e27629ac065b95b223dd3481b784cdb",
+      "sourceSha256": "eb353aac6e8446477a4bec01c438506ee28ab7142347e8f4dda3b454e203eee0",
       "artifactPath": "package.json",
-      "expectedSha256": "72c18243bc9007a32089e0880e51f4553e27629ac065b95b223dd3481b784cdb",
+      "expectedSha256": "eb353aac6e8446477a4bec01c438506ee28ab7142347e8f4dda3b454e203eee0",
       "byteForByte": true
     },
     {
       "name": "release-manifest",
       "sourcePath": "libnode.release.json",
-      "sourceSha256": "4c32420d0e3f323df92d0fdae612356ab44d4400daf586428f2370e069f82675",
+      "sourceSha256": "d2a4e4ff763402dee6fb2c571f397a07b760f9d770064bf2943708c0da65ec8d",
       "artifactPath": "libnode.release.json",
-      "expectedSha256": "4c32420d0e3f323df92d0fdae612356ab44d4400daf586428f2370e069f82675",
+      "expectedSha256": "d2a4e4ff763402dee6fb2c571f397a07b760f9d770064bf2943708c0da65ec8d",
       "byteForByte": true
     },
     {
@@ -97,9 +97,9 @@
     {
       "name": "kfd3-prebuild-witness",
       "sourcePath": ".buildchain/kfd-3/collaboration-interface.prebuild.json",
-      "sourceSha256": "28de2d88dbab94b1c183505ab7021d4b592c6005e7b743fb81ab23e625346e2a",
+      "sourceSha256": "e467c11969fb28cedacbd889427f38050a668258abc77382c043f58e9aab7fd4",
       "artifactPath": ".buildchain/kfd-3/collaboration-interface.prebuild.json",
-      "expectedSha256": "28de2d88dbab94b1c183505ab7021d4b592c6005e7b743fb81ab23e625346e2a",
+      "expectedSha256": "e467c11969fb28cedacbd889427f38050a668258abc77382c043f58e9aab7fd4",
       "byteForByte": true
     }
   ]

--- a/.buildchain/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd-3/collaboration-interface.prebuild.json
@@ -11,7 +11,7 @@
   "sourceRegistry": {
     "id": "libnode-release-contract",
     "path": "libnode.release.json",
-    "version": "22.22.3-kf.3-alpha.19"
+    "version": "22.22.3-kf.3-alpha.20"
   },
   "collaborationInterfaceDigest": "sha256:da72832c4fee28021f90381b86ed94ccf6d8bddcb23b80419d256e5a9e4bb653",
   "collaborationInterface": {

--- a/buildchain.alpha-contract-lock.json
+++ b/buildchain.alpha-contract-lock.json
@@ -3,13 +3,13 @@
   "contract": "kungfu-buildchain-contract-lock",
   "buildchain": {
     "ref": "v2-alpha",
-    "resolvedSha": "8270576a1a37d3d8464a10ddeff5c9da450cc22e",
+    "resolvedSha": "701cca28a5bf9fe6dcf49c26097572bbe5f39a8b",
     "contract": "kungfu-buildchain-runtime-contract-world",
-    "contractDigest": "sha256:81c7c3721fa796b8d4585b0d8495822e405dd1e68b3a31db55934d4bf5687997",
+    "contractDigest": "sha256:01282a8e51767f52f821295b2258b0f8ef67525ba30c2973f9309645088bc70e",
     "compatibilityDigest": "sha256:edc3653e5cb34efd97065a6941db16140bbf375a565bbcf329d9d795bb07676f",
     "majorLine": "v2",
     "compatibilityPolicy": "major-compatible",
-    "acceptedAt": "2026-07-19T05:28:32.451Z",
+    "acceptedAt": "2026-07-19T14:20:41.000Z",
     "surfaces": [
       {
         "id": "reusable-build",

--- a/buildchain.contract-lock.json
+++ b/buildchain.contract-lock.json
@@ -3,13 +3,13 @@
   "contract": "kungfu-buildchain-contract-lock",
   "buildchain": {
     "ref": "v2",
-    "resolvedSha": "c95f9fc36b0ac8fb4ff6400189850c4ae683f3ea",
+    "resolvedSha": "565354f7b8abdbd68576468c04bfbcfc57d267e2",
     "contract": "kungfu-buildchain-runtime-contract-world",
-    "contractDigest": "sha256:90466f4b69982ad1aba65d22596baa4cd0112454f44b1f7c33ab3de017029a06",
-    "compatibilityDigest": "sha256:af162b86ab4506e9b5f1d3c59b41f3fd57fbad79ff4d749a7f12ff16460517f8",
+    "contractDigest": "sha256:53d4d8d89dbccb802e95c3b0b3bef2c857fccff136fc419cd70c6fb450c516dd",
+    "compatibilityDigest": "sha256:edc3653e5cb34efd97065a6941db16140bbf375a565bbcf329d9d795bb07676f",
     "majorLine": "v2",
     "compatibilityPolicy": "major-compatible",
-    "acceptedAt": "2026-07-18T15:27:29.000Z",
+    "acceptedAt": "2026-07-19T14:37:49.000Z",
     "surfaces": [
       {
         "id": "reusable-build",
@@ -24,7 +24,12 @@
       {
         "id": "release-candidate-promote",
         "kind": "workflow",
-        "breakingDigest": "sha256:6dbae32ce3d7aab3be6957065105af574794581847b7637314dad45f5349c919"
+        "breakingDigest": "sha256:1f476fb9a4854b362c4b24cef89a3c7675d7d63baf3bc828d7b8ae7d2787cead"
+      },
+      {
+        "id": "advanced-release-candidate-promote",
+        "kind": "workflow",
+        "breakingDigest": "sha256:aa30f22e3af0a89841310bdbdc900844dd95a66974db173fa140a71bbd7e82c0"
       },
       {
         "id": "web-surface",
@@ -124,7 +129,7 @@
       {
         "id": "controller:release-candidate-promotion",
         "kind": "controller",
-        "breakingDigest": "sha256:46238f8fc3c20924decc57ecad142a462fc4739c6bc21409d5cd2457fc1c3cdd"
+        "breakingDigest": "sha256:015d8de793adbd4c539416be7d7512e18cc92097e629b0203fa06d2c183e98bd"
       },
       {
         "id": "controller:release-propagation",

--- a/libnode.release.json
+++ b/libnode.release.json
@@ -4,5 +4,5 @@
   "nodeTag": "v22.22.3",
   "nodeCommit": "fdfa0ff0dbaf0fbf4d7d6d89a2ab807f3177fa5c",
   "libnodeRevision": 3,
-  "npmVersion": "22.22.3-kf.3-alpha.19"
+  "npmVersion": "22.22.3-kf.3-alpha.20"
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "name": "kungfu-trader",
     "email": "info@kungfu.link"
   },
-  "version": "22.22.3-kf.3-alpha.19",
+  "version": "22.22.3-kf.3-alpha.20",
   "description": "Build shared node lib",
   "license": "Apache-2.0",
   "main": "src/js/index.js",


### PR DESCRIPTION
## Summary
- advance the anchored package version to `22.22.3-kf.3-alpha.20`
- carry the Buildchain v2.14.3 stable/alpha contract locks already reviewed on `dev/v22/v22.22`
- refresh KFD-1 and KFD-3 witnesses from the version truth files

## Verification
- `corepack pnpm verify-release`
- `corepack pnpm verify-kfd-witnesses`
- `corepack pnpm verify-package-source`
- `corepack pnpm pack --dry-run`
- `corepack pnpm exec buildchain validate --require-version-state --require-lifecycle-stages install,build,verify,publish`
- `actionlint .github/workflows/*.yml .github/workflows/*.yaml`
- `git diff --check`

This is the strict Buildchain alpha publish-gate prerequisite for the next production release. The PR-stage build must qualify all three native platforms before merge; post-merge publication must reuse that candidate.