### PR TITLE
chore(release): prepare libnode alpha 21

### DIFF
--- a/.buildchain/kfd-1/libnode-contract-world.witness.json
+++ b/.buildchain/kfd-1/libnode-contract-world.witness.json
@@ -10,12 +10,12 @@
   "contractWorld": {
     "id": "libnode-release-contract",
     "schemaId": "https://kfd.libkungfu.dev/schemas/kfd-1/contract-world.schema.json",
-    "digest": "sha256:d2a4e4ff763402dee6fb2c571f397a07b760f9d770064bf2943708c0da65ec8d"
+    "digest": "sha256:b30f9d551fc53f1ed945f7fb896490277804c1a93067e5384212fef9e9408df6"
   },
   "standardContract": {
     "id": "libnode-release-contract",
     "path": "libnode.release.json",
-    "sha256": "d2a4e4ff763402dee6fb2c571f397a07b760f9d770064bf2943708c0da65ec8d"
+    "sha256": "b30f9d551fc53f1ed945f7fb896490277804c1a93067e5384212fef9e9408df6"
   },
   "selfHostingBoundary": {
     "mode": "self-hosted-standard-contract",
@@ -33,25 +33,25 @@
     {
       "name": "package-manifest",
       "sourcePath": "package.json",
-      "sourceSha256": "eb353aac6e8446477a4bec01c438506ee28ab7142347e8f4dda3b454e203eee0",
+      "sourceSha256": "fa208a571d294ed35f1c5689b186be58f6bfefa08f6e4e049f393ea632d6c4d9",
       "artifactPath": "package.json",
-      "expectedSha256": "eb353aac6e8446477a4bec01c438506ee28ab7142347e8f4dda3b454e203eee0",
+      "expectedSha256": "fa208a571d294ed35f1c5689b186be58f6bfefa08f6e4e049f393ea632d6c4d9",
       "byteForByte": true
     },
     {
       "name": "release-manifest",
       "sourcePath": "libnode.release.json",
-      "sourceSha256": "d2a4e4ff763402dee6fb2c571f397a07b760f9d770064bf2943708c0da65ec8d",
+      "sourceSha256": "b30f9d551fc53f1ed945f7fb896490277804c1a93067e5384212fef9e9408df6",
       "artifactPath": "libnode.release.json",
-      "expectedSha256": "d2a4e4ff763402dee6fb2c571f397a07b760f9d770064bf2943708c0da65ec8d",
+      "expectedSha256": "b30f9d551fc53f1ed945f7fb896490277804c1a93067e5384212fef9e9408df6",
       "byteForByte": true
     },
     {
       "name": "buildchain-config",
       "sourcePath": "buildchain.toml",
-      "sourceSha256": "1ed7e2677a7b551264f86a40c6985adeebca590a942e358a57844b5d05a2aa3d",
+      "sourceSha256": "cbac4d504308285a41dd04482b8aab18238481e641c74d1f3c0f47b6652a9ef7",
       "artifactPath": "buildchain.toml",
-      "expectedSha256": "1ed7e2677a7b551264f86a40c6985adeebca590a942e358a57844b5d05a2aa3d",
+      "expectedSha256": "cbac4d504308285a41dd04482b8aab18238481e641c74d1f3c0f47b6652a9ef7",
       "byteForByte": true
     },
     {
@@ -97,9 +97,9 @@
     {
       "name": "kfd3-prebuild-witness",
       "sourcePath": ".buildchain/kfd-3/collaboration-interface.prebuild.json",
-      "sourceSha256": "e467c11969fb28cedacbd889427f38050a668258abc77382c043f58e9aab7fd4",
+      "sourceSha256": "042adc7a140d4359c191b3c28c84f55a9192cd35fa3a1c5ad039be0f6fccf319",
       "artifactPath": ".buildchain/kfd-3/collaboration-interface.prebuild.json",
-      "expectedSha256": "e467c11969fb28cedacbd889427f38050a668258abc77382c043f58e9aab7fd4",
+      "expectedSha256": "042adc7a140d4359c191b3c28c84f55a9192cd35fa3a1c5ad039be0f6fccf319",
       "byteForByte": true
     }
   ]

--- a/.buildchain/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd-3/collaboration-interface.prebuild.json
@@ -11,7 +11,7 @@
   "sourceRegistry": {
     "id": "libnode-release-contract",
     "path": "libnode.release.json",
-    "version": "22.22.3-kf.3-alpha.20"
+    "version": "22.22.3-kf.3-alpha.21"
   },
   "collaborationInterfaceDigest": "sha256:da72832c4fee28021f90381b86ed94ccf6d8bddcb23b80419d256e5a9e4bb653",
   "collaborationInterface": {

--- a/buildchain.alpha-contract-lock.json
+++ b/buildchain.alpha-contract-lock.json
@@ -3,13 +3,13 @@
   "contract": "kungfu-buildchain-contract-lock",
   "buildchain": {
     "ref": "v2-alpha",
-    "resolvedSha": "701cca28a5bf9fe6dcf49c26097572bbe5f39a8b",
+    "resolvedSha": "9324835dcdd6e7611fe268c6551ffd4ef8284161",
     "contract": "kungfu-buildchain-runtime-contract-world",
-    "contractDigest": "sha256:01282a8e51767f52f821295b2258b0f8ef67525ba30c2973f9309645088bc70e",
+    "contractDigest": "sha256:283d92cc0cf02ba5a6d179cb3d1c7599732e41722b93f81ee02b7962f5b2f137",
     "compatibilityDigest": "sha256:edc3653e5cb34efd97065a6941db16140bbf375a565bbcf329d9d795bb07676f",
     "majorLine": "v2",
     "compatibilityPolicy": "major-compatible",
-    "acceptedAt": "2026-07-19T14:20:41.000Z",
+    "acceptedAt": "2026-07-20T21:35:41.000Z",
     "surfaces": [
       {
         "id": "reusable-build",

--- a/buildchain.contract-lock.json
+++ b/buildchain.contract-lock.json
@@ -3,13 +3,13 @@
   "contract": "kungfu-buildchain-contract-lock",
   "buildchain": {
     "ref": "v2",
-    "resolvedSha": "565354f7b8abdbd68576468c04bfbcfc57d267e2",
+    "resolvedSha": "3f7a5e4c82141dbd8568f3adc15e5bca3e5ec402",
     "contract": "kungfu-buildchain-runtime-contract-world",
-    "contractDigest": "sha256:53d4d8d89dbccb802e95c3b0b3bef2c857fccff136fc419cd70c6fb450c516dd",
+    "contractDigest": "sha256:fa31f0a0692c23c6d7fb2bc605e0b6bfdb40e3b28f63b2f85f0f63cebaec42c9",
     "compatibilityDigest": "sha256:edc3653e5cb34efd97065a6941db16140bbf375a565bbcf329d9d795bb07676f",
     "majorLine": "v2",
     "compatibilityPolicy": "major-compatible",
-    "acceptedAt": "2026-07-19T14:37:49.000Z",
+    "acceptedAt": "2026-07-20T21:55:19.000Z",
     "surfaces": [
       {
         "id": "reusable-build",

--- a/buildchain.toml
+++ b/buildchain.toml
@@ -5,6 +5,10 @@ required = true
 strategy = "anchored"
 next = "manual"
 manifest = "libnode.release.json"
+derived_files = [
+  ".buildchain/kfd-1/libnode-contract-world.witness.json",
+  ".buildchain/kfd-3/collaboration-interface.prebuild.json",
+]
 
 [[version.files]]
 type = "json"
@@ -64,6 +68,10 @@ commands = [
   "node .gyp/run-with-env.js KF_SKIP_MAKE_LIBNODE=true -- corepack pnpm build",
   "corepack pnpm package",
 ]
+
+[lifecycle.version-state]
+timeout_minutes = 10
+command = "corepack pnpm sync-kfd-witnesses"
 
 [lifecycle.verify]
 timeout_minutes = 10

--- a/libnode.release.json
+++ b/libnode.release.json
@@ -4,5 +4,5 @@
   "nodeTag": "v22.22.3",
   "nodeCommit": "fdfa0ff0dbaf0fbf4d7d6d89a2ab807f3177fa5c",
   "libnodeRevision": 3,
-  "npmVersion": "22.22.3-kf.3-alpha.20"
+  "npmVersion": "22.22.3-kf.3-alpha.21"
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "name": "kungfu-trader",
     "email": "info@kungfu.link"
   },
-  "version": "22.22.3-kf.3-alpha.20",
+  "version": "22.22.3-kf.3-alpha.21",
   "description": "Build shared node lib",
   "license": "Apache-2.0",
   "main": "src/js/index.js",


### PR DESCRIPTION
## Summary
- declare anchored derived version material and lifecycle.version-state
- accept Buildchain v2.14.5 stable/alpha contract locks
- prepare 22.22.3-kf.3-alpha.21 for one-pass three-platform validation

## Local verification
- buildchain validate --require-version-state --require-lifecycle-stages install,build,version-state,verify,publish
- pnpm sync-kfd-witnesses (idempotent)
- pnpm verify-release
- pnpm verify-kfd-witnesses
- pnpm verify-package-source
- pnpm pack --dry-run
- git diff --check