### PR TITLE
chore(governance): add code owner authority

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# GitHub review and governance authority.
+* @kungfu-origin
+
+# Last-match rules make authority and publication control surfaces explicit.
+/.github/CODEOWNERS @kungfu-origin
+/.github/workflows/ @kungfu-origin
+/buildchain.toml @kungfu-origin
+/buildchain.contract-lock.json @kungfu-origin
+/buildchain.alpha-contract-lock.json @kungfu-origin
+/libnode.release.json @kungfu-origin


### PR DESCRIPTION
## Summary
- assign repository ownership to `@kungfu-origin`
- explicitly protect CODEOWNERS, workflow, Buildchain contract, and release-control surfaces

## Validation
- CODEOWNERS owner resolves as an active organization member
- `git diff --check`

Signed-off-by: Keren Dong <keren.dong@kungfu.link>