### PR TITLE
chore(governance): promote code owner authority to alpha

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# GitHub review and governance authority.
+* @kungfu-origin
+
+# Last-match rules make authority and publication control surfaces explicit.
+/.github/CODEOWNERS @kungfu-origin
+/.github/workflows/ @kungfu-origin
+/buildchain.toml @kungfu-origin
+/buildchain.contract-lock.json @kungfu-origin
+/buildchain.alpha-contract-lock.json @kungfu-origin
+/libnode.release.json @kungfu-origin


### PR DESCRIPTION
## Summary

Promote the independently reviewed CODEOWNERS authority from the governed development line to alpha.

## Scope

- forward-only channel promotion
- exactly the CODEOWNERS authority commit and its merge commit
- no required check, bypass, or proof-identity relaxation