### PR TITLE
chore(governance): promote code owner authority to release

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# GitHub review and governance authority.
+* @kungfu-origin
+
+# Last-match rules make authority and publication control surfaces explicit.
+/.github/CODEOWNERS @kungfu-origin
+/.github/workflows/ @kungfu-origin
+/buildchain.toml @kungfu-origin
+/buildchain.contract-lock.json @kungfu-origin
+/buildchain.alpha-contract-lock.json @kungfu-origin
+/libnode.release.json @kungfu-origin


### PR DESCRIPTION
## Summary

Propagate the independently reviewed CODEOWNERS authority from alpha into the release line.

## Scope

- the branches have historical release-only commits, but the effective PR file diff is exactly one added `.github/CODEOWNERS` file
- no required-check, bypass, or proof-identity relaxation
- merge only after the complete native release matrix and independent review pass