### PR TITLE
chore(governance): add release code owner authority

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# GitHub review and governance authority.
+* @kungfu-origin
+
+# Last-match rules make authority and publication control surfaces explicit.
+/.github/CODEOWNERS @kungfu-origin
+/.github/workflows/ @kungfu-origin
+/buildchain.toml @kungfu-origin
+/buildchain.contract-lock.json @kungfu-origin
+/buildchain.alpha-contract-lock.json @kungfu-origin
+/libnode.release.json @kungfu-origin


### PR DESCRIPTION
## Summary

Add the exact authoritative CODEOWNERS source blob to this protected target without merging unrelated channel history.

## Safety

- branch created from the frozen target base SHA
- single-file `.github/CODEOWNERS` change
- DCO-signed commit and independent `kungfu-origin` review
- no direct protected-ref write, administrator merge, required-check relaxation, or affected-native proof change