### PR TITLE
feat(packages): publish Linux ARM64 libnode

### DIFF
--- a/.buildchain/kfd-1/libnode-contract-world.witness.json
+++ b/.buildchain/kfd-1/libnode-contract-world.witness.json
@@ -10,12 +10,12 @@
   "contractWorld": {
     "id": "libnode-release-contract",
     "schemaId": "https://kfd.libkungfu.dev/schemas/kfd-1/contract-world.schema.json",
-    "digest": "sha256:42ae74acebcbf3b523518014ea7d34a31fba680e9706f64c6c4518fe3b6a8232"
+    "digest": "sha256:c29741c757402b17ff91b026899c8ba91a9a4d9f58ccf817848b4cf7ef7d7bcf"
   },
   "standardContract": {
     "id": "libnode-release-contract",
     "path": "libnode.release.json",
-    "sha256": "42ae74acebcbf3b523518014ea7d34a31fba680e9706f64c6c4518fe3b6a8232"
+    "sha256": "c29741c757402b17ff91b026899c8ba91a9a4d9f58ccf817848b4cf7ef7d7bcf"
   },
   "selfHostingBoundary": {
     "mode": "self-hosted-standard-contract",
@@ -33,17 +33,17 @@
     {
       "name": "package-manifest",
       "sourcePath": "package.json",
-      "sourceSha256": "5f99610683e62ab5c708a177c0273854231d18ca48a63b55cde5bb7f9695161c",
+      "sourceSha256": "835c764e2412cbe214ec992ebcecbd0e5649adce373e8a14b8374084646387ab",
       "artifactPath": "package.json",
-      "expectedSha256": "5f99610683e62ab5c708a177c0273854231d18ca48a63b55cde5bb7f9695161c",
+      "expectedSha256": "835c764e2412cbe214ec992ebcecbd0e5649adce373e8a14b8374084646387ab",
       "byteForByte": true
     },
     {
       "name": "release-manifest",
       "sourcePath": "libnode.release.json",
-      "sourceSha256": "42ae74acebcbf3b523518014ea7d34a31fba680e9706f64c6c4518fe3b6a8232",
+      "sourceSha256": "c29741c757402b17ff91b026899c8ba91a9a4d9f58ccf817848b4cf7ef7d7bcf",
       "artifactPath": "libnode.release.json",
-      "expectedSha256": "42ae74acebcbf3b523518014ea7d34a31fba680e9706f64c6c4518fe3b6a8232",
+      "expectedSha256": "c29741c757402b17ff91b026899c8ba91a9a4d9f58ccf817848b4cf7ef7d7bcf",
       "byteForByte": true
     },
     {
@@ -97,9 +97,9 @@
     {
       "name": "kfd3-prebuild-witness",
       "sourcePath": ".buildchain/kfd-3/collaboration-interface.prebuild.json",
-      "sourceSha256": "76cb8cdc7eccbc77bed3ae6918551925aad21a88b8cdd993869b4ab16e2865f8",
+      "sourceSha256": "c7ae8d49e97e9b99c7393dbec05c63f0a038f20d76928a7b170e5b6d0fee1626",
       "artifactPath": ".buildchain/kfd-3/collaboration-interface.prebuild.json",
-      "expectedSha256": "76cb8cdc7eccbc77bed3ae6918551925aad21a88b8cdd993869b4ab16e2865f8",
+      "expectedSha256": "c7ae8d49e97e9b99c7393dbec05c63f0a038f20d76928a7b170e5b6d0fee1626",
       "byteForByte": true
     }
   ]

--- a/.buildchain/kfd-1/libnode-contract-world.witness.json
+++ b/.buildchain/kfd-1/libnode-contract-world.witness.json
@@ -10,12 +10,12 @@
   "contractWorld": {
     "id": "libnode-release-contract",
     "schemaId": "https://kfd.libkungfu.dev/schemas/kfd-1/contract-world.schema.json",
-    "digest": "sha256:b30f9d551fc53f1ed945f7fb896490277804c1a93067e5384212fef9e9408df6"
+    "digest": "sha256:42ae74acebcbf3b523518014ea7d34a31fba680e9706f64c6c4518fe3b6a8232"
   },
   "standardContract": {
     "id": "libnode-release-contract",
     "path": "libnode.release.json",
-    "sha256": "b30f9d551fc53f1ed945f7fb896490277804c1a93067e5384212fef9e9408df6"
+    "sha256": "42ae74acebcbf3b523518014ea7d34a31fba680e9706f64c6c4518fe3b6a8232"
   },
   "selfHostingBoundary": {
     "mode": "self-hosted-standard-contract",
@@ -33,17 +33,17 @@
     {
       "name": "package-manifest",
       "sourcePath": "package.json",
-      "sourceSha256": "fa208a571d294ed35f1c5689b186be58f6bfefa08f6e4e049f393ea632d6c4d9",
+      "sourceSha256": "5f99610683e62ab5c708a177c0273854231d18ca48a63b55cde5bb7f9695161c",
       "artifactPath": "package.json",
-      "expectedSha256": "fa208a571d294ed35f1c5689b186be58f6bfefa08f6e4e049f393ea632d6c4d9",
+      "expectedSha256": "5f99610683e62ab5c708a177c0273854231d18ca48a63b55cde5bb7f9695161c",
       "byteForByte": true
     },
     {
       "name": "release-manifest",
       "sourcePath": "libnode.release.json",
-      "sourceSha256": "b30f9d551fc53f1ed945f7fb896490277804c1a93067e5384212fef9e9408df6",
+      "sourceSha256": "42ae74acebcbf3b523518014ea7d34a31fba680e9706f64c6c4518fe3b6a8232",
       "artifactPath": "libnode.release.json",
-      "expectedSha256": "b30f9d551fc53f1ed945f7fb896490277804c1a93067e5384212fef9e9408df6",
+      "expectedSha256": "42ae74acebcbf3b523518014ea7d34a31fba680e9706f64c6c4518fe3b6a8232",
       "byteForByte": true
     },
     {
@@ -57,9 +57,9 @@
     {
       "name": "package-builder",
       "sourcePath": ".gyp/node-platform-package.js",
-      "sourceSha256": "7871e2dc7240ebf69de06b4016c7715417d3273f3b0231b5f0459e5dd8b94bea",
+      "sourceSha256": "e457328484352bb48404872dad0a6747bfdfb78c67dbb1d8f0cd5d93ae5fecd4",
       "artifactPath": ".gyp/node-platform-package.js",
-      "expectedSha256": "7871e2dc7240ebf69de06b4016c7715417d3273f3b0231b5f0459e5dd8b94bea",
+      "expectedSha256": "e457328484352bb48404872dad0a6747bfdfb78c67dbb1d8f0cd5d93ae5fecd4",
       "byteForByte": true
     },
     {
@@ -73,33 +73,33 @@
     {
       "name": "kfd3-artifact-verifier",
       "sourcePath": ".gyp/libnode-kfd3-artifact-verify.js",
-      "sourceSha256": "a6a15fe9a54b02dd2cc78a69300ad9af3fa7ce7c6bcab652e6c6049198ddc172",
+      "sourceSha256": "783b329aeaa4b2196db5c754ff2c8ac247467af8655d8caba52755e5e88677ba",
       "artifactPath": ".gyp/libnode-kfd3-artifact-verify.js",
-      "expectedSha256": "a6a15fe9a54b02dd2cc78a69300ad9af3fa7ce7c6bcab652e6c6049198ddc172",
+      "expectedSha256": "783b329aeaa4b2196db5c754ff2c8ac247467af8655d8caba52755e5e88677ba",
       "byteForByte": true
     },
     {
       "name": "release-workflow",
       "sourcePath": ".github/workflows/release-new-version.yml",
-      "sourceSha256": "a7bc52b1c868edda17499f204ab43f8b9bc5a74daf25c2f0eb2b08fbf859e1d2",
+      "sourceSha256": "91b87a6248668d93498af626d038df5925363d31393518c01ddbfdf5ae83ff4d",
       "artifactPath": ".github/workflows/release-new-version.yml",
-      "expectedSha256": "a7bc52b1c868edda17499f204ab43f8b9bc5a74daf25c2f0eb2b08fbf859e1d2",
+      "expectedSha256": "91b87a6248668d93498af626d038df5925363d31393518c01ddbfdf5ae83ff4d",
       "byteForByte": true
     },
     {
       "name": "kfd3-collaboration-interface",
       "sourcePath": ".buildchain/kfd-3/collaboration-interface.json",
-      "sourceSha256": "da72832c4fee28021f90381b86ed94ccf6d8bddcb23b80419d256e5a9e4bb653",
+      "sourceSha256": "bbdfc87c532fe50fca92ca8415fc624af95c79fa7c9a4825efcee233701bd8c8",
       "artifactPath": ".buildchain/kfd-3/collaboration-interface.json",
-      "expectedSha256": "da72832c4fee28021f90381b86ed94ccf6d8bddcb23b80419d256e5a9e4bb653",
+      "expectedSha256": "bbdfc87c532fe50fca92ca8415fc624af95c79fa7c9a4825efcee233701bd8c8",
       "byteForByte": true
     },
     {
       "name": "kfd3-prebuild-witness",
       "sourcePath": ".buildchain/kfd-3/collaboration-interface.prebuild.json",
-      "sourceSha256": "042adc7a140d4359c191b3c28c84f55a9192cd35fa3a1c5ad039be0f6fccf319",
+      "sourceSha256": "76cb8cdc7eccbc77bed3ae6918551925aad21a88b8cdd993869b4ab16e2865f8",
       "artifactPath": ".buildchain/kfd-3/collaboration-interface.prebuild.json",
-      "expectedSha256": "042adc7a140d4359c191b3c28c84f55a9192cd35fa3a1c5ad039be0f6fccf319",
+      "expectedSha256": "76cb8cdc7eccbc77bed3ae6918551925aad21a88b8cdd993869b4ab16e2865f8",
       "byteForByte": true
     }
   ]

--- a/.buildchain/kfd-3/collaboration-interface.json
+++ b/.buildchain/kfd-3/collaboration-interface.json
@@ -56,6 +56,16 @@
       "sourcePath": ".gyp/node-platform-package.js"
     },
     {
+      "id": "npm:platform-linux-arm64",
+      "name": "@kungfu-tech/libnode-linux-arm64 package",
+      "kind": "platform-package",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": ".gyp/node-platform-package.js"
+    },
+    {
       "id": "npm:platform-win32-x64",
       "name": "@kungfu-tech/libnode-win32-x64 package",
       "kind": "platform-package",
@@ -135,7 +145,7 @@
     "The npm version is anchored to libnode.release.json npmVersion.",
     "The upstream Node version is anchored to libnode.release.json nodeTag and nodeCommit.",
     "The release package set is published platforms-first and main-last.",
-    "macOS arm64, Linux x64, and Windows x64 platform packages are public release surfaces.",
+    "macOS arm64, Linux x64, Linux arm64, and Windows x64 platform packages are public release surfaces.",
     "macOS and Linux link aliases are materialized by package postinstall policy instead of npm tarball symlinks.",
     "Windows packages must include both DLL and import library outputs."
   ],

--- a/.buildchain/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd-3/collaboration-interface.prebuild.json
@@ -11,13 +11,13 @@
   "sourceRegistry": {
     "id": "libnode-release-contract",
     "path": "libnode.release.json",
-    "version": "22.22.3-kf.3-alpha.21"
+    "version": "22.22.3-kf.3-alpha.22"
   },
-  "collaborationInterfaceDigest": "sha256:da72832c4fee28021f90381b86ed94ccf6d8bddcb23b80419d256e5a9e4bb653",
+  "collaborationInterfaceDigest": "sha256:bbdfc87c532fe50fca92ca8415fc624af95c79fa7c9a4825efcee233701bd8c8",
   "collaborationInterface": {
     "schemaVersion": 1,
     "contract": "kfd-3-collaboration-interface",
-    "digest": "sha256:da72832c4fee28021f90381b86ed94ccf6d8bddcb23b80419d256e5a9e4bb653",
+    "digest": "sha256:bbdfc87c532fe50fca92ca8415fc624af95c79fa7c9a4825efcee233701bd8c8",
     "product": {
       "name": "Libnode",
       "package": "@kungfu-tech/libnode",

--- a/.buildchain/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd-3/collaboration-interface.prebuild.json
@@ -11,7 +11,7 @@
   "sourceRegistry": {
     "id": "libnode-release-contract",
     "path": "libnode.release.json",
-    "version": "22.22.3-kf.3-alpha.22"
+    "version": "22.22.3-kf.5-alpha.1"
   },
   "collaborationInterfaceDigest": "sha256:bbdfc87c532fe50fca92ca8415fc624af95c79fa7c9a4825efcee233701bd8c8",
   "collaborationInterface": {

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ on:
       - alpha/v*/v*.*
 
 permissions:
+  actions: read
   contents: read
   issues: write
   id-token: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,9 @@ jobs:
   build-matrix:
     uses: kungfu-systems/buildchain/.github/workflows/build.yml@v2
     with:
-      runner-preset: kungfu-v4-self-hosted
+      runner-preset: custom
+      platforms-json: >-
+        [{"id":"linux-x64","name":"Linux x64","platform":"linux","runner":"[\"self-hosted\",\"Linux\",\"X64\",\"kungfu-build-v4-linux-x64\"]","capabilities":["node","native-toolchain","product-artifacts"]},{"id":"linux-arm64","name":"Linux ARM64","platform":"linux","runner":"[\"ubuntu-24.04-arm\"]","capabilities":["node","native-toolchain","product-artifacts"]},{"id":"macos-arm64","name":"macOS ARM64","platform":"macos","runner":"[\"self-hosted\",\"macOS\",\"ARM64\",\"kungfu-build-v4-macos-arm64\"]","capabilities":["node","native-toolchain","product-artifacts"]},{"id":"windows-x64","name":"Windows x64","platform":"windows","runner":"[\"self-hosted\",\"Windows\",\"X64\",\"kungfu-build-v4-windows-x64\"]","capabilities":["node","native-toolchain","product-artifacts"]}]
       buildchain-alpha-contract-lock-path: buildchain.alpha-contract-lock.json
       buildchain-stable-contract-lock-path: buildchain.contract-lock.json
       buildchain-contract-drift-issue-mode: compatible-and-breaking

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -34,9 +34,10 @@ jobs:
       artifact-patterns: |
         libnode-macos-arm64-*
         libnode-linux-x64-*
+        libnode-linux-arm64-*
         libnode-windows-x64-*
       required-status-check: build
-      required-artifact-count: 3
+      required-artifact-count: 4
       publish-mode: publish-final-version
       publish-dist-tag: ${{ startsWith(github.ref_name, 'alpha/') && 'alpha' || 'latest' }}
       publish-package-set-order: platforms-first-main-last

--- a/.github/workflows/release-verify.yaml
+++ b/.github/workflows/release-verify.yaml
@@ -20,7 +20,9 @@ jobs:
   build:
     uses: kungfu-systems/buildchain/.github/workflows/build.yml@v2
     with:
-      runner-preset: kungfu-v4-self-hosted
+      runner-preset: custom
+      platforms-json: >-
+        [{"id":"linux-x64","name":"Linux x64","platform":"linux","runner":"[\"self-hosted\",\"Linux\",\"X64\",\"kungfu-build-v4-linux-x64\"]","capabilities":["node","native-toolchain","product-artifacts"]},{"id":"linux-arm64","name":"Linux ARM64","platform":"linux","runner":"[\"ubuntu-24.04-arm\"]","capabilities":["node","native-toolchain","product-artifacts"]},{"id":"macos-arm64","name":"macOS ARM64","platform":"macos","runner":"[\"self-hosted\",\"macOS\",\"ARM64\",\"kungfu-build-v4-macos-arm64\"]","capabilities":["node","native-toolchain","product-artifacts"]},{"id":"windows-x64","name":"Windows x64","platform":"windows","runner":"[\"self-hosted\",\"Windows\",\"X64\",\"kungfu-build-v4-windows-x64\"]","capabilities":["node","native-toolchain","product-artifacts"]}]
       buildchain-alpha-contract-lock-path: buildchain.alpha-contract-lock.json
       buildchain-stable-contract-lock-path: buildchain.contract-lock.json
       buildchain-contract-drift-issue-mode: compatible-and-breaking

--- a/.github/workflows/release-verify.yaml
+++ b/.github/workflows/release-verify.yaml
@@ -8,6 +8,7 @@ on:
       - release/v*/v*.*
 
 permissions:
+  actions: read
   contents: read
   issues: write
   id-token: write

--- a/.gyp/libnode-kfd3-artifact-verify.js
+++ b/.gyp/libnode-kfd3-artifact-verify.js
@@ -15,7 +15,8 @@ const payloadRoot = path.resolve(
 const packageNames = {
   main: '@kungfu-tech/libnode',
   darwin: '@kungfu-tech/libnode-darwin-arm64',
-  linux: '@kungfu-tech/libnode-linux-x64',
+  linuxX64: '@kungfu-tech/libnode-linux-x64',
+  linuxArm64: '@kungfu-tech/libnode-linux-arm64',
   windows: '@kungfu-tech/libnode-win32-x64',
 };
 
@@ -135,13 +136,15 @@ function main() {
   const files = {
     main: findPackageTarball(packageNames.main),
     darwin: findPackageTarball(packageNames.darwin),
-    linux: findPackageTarball(packageNames.linux),
+    linuxX64: findPackageTarball(packageNames.linuxX64),
+    linuxArm64: findPackageTarball(packageNames.linuxArm64),
     windows: findPackageTarball(packageNames.windows),
   };
 
   verifyMainPackage(files.main);
   verifyDarwinPackage(files.darwin);
-  verifyLinuxPackage(files.linux);
+  verifyLinuxPackage(files.linuxX64);
+  verifyLinuxPackage(files.linuxArm64);
   verifyWindowsPackage(files.windows);
 
   const digests = Object.fromEntries(Object.entries(files).map(([key, file]) => [key, `sha256:${sha256File(file)}`]));
@@ -188,6 +191,12 @@ function main() {
       surface(
         'npm:platform-linux-x64',
         '@kungfu-tech/libnode-linux-x64 package',
+        'platform-package',
+        '.gyp/node-platform-package.js',
+      ),
+      surface(
+        'npm:platform-linux-arm64',
+        '@kungfu-tech/libnode-linux-arm64 package',
         'platform-package',
         '.gyp/node-platform-package.js',
       ),

--- a/.gyp/node-platform-package.js
+++ b/.gyp/node-platform-package.js
@@ -28,6 +28,14 @@ const platformPackages = [
     aliases: [{ source: 'libnode.so.*', match: '^libnode\\.so\\.\\d+$', target: 'libnode.so' }],
   },
   {
+    key: 'linux-arm64',
+    name: '@kungfu-tech/libnode-linux-arm64',
+    os: ['linux'],
+    cpu: ['arm64'],
+    binaries: ['libnode.so*'],
+    aliases: [{ source: 'libnode.so.*', match: '^libnode\\.so\\.\\d+$', target: 'libnode.so' }],
+  },
+  {
     key: 'win32-x64',
     name: '@kungfu-tech/libnode-win32-x64',
     os: ['win32'],

--- a/.gyp/npm-publish-tarballs.js
+++ b/.gyp/npm-publish-tarballs.js
@@ -15,6 +15,10 @@ const platformPackageRequirements = {
     binaries: [/^package\/dist\/node\/libnode\.so\.\d+$/],
     aliases: [{ target: 'package/dist/node/libnode.so', helper: 'package/ensure-libnode-aliases.js' }],
   },
+  '@kungfu-tech/libnode-linux-arm64': {
+    binaries: [/^package\/dist\/node\/libnode\.so\.\d+$/],
+    aliases: [{ target: 'package/dist/node/libnode.so', helper: 'package/ensure-libnode-aliases.js' }],
+  },
   '@kungfu-tech/libnode-win32-x64': {
     binaries: [/^package\/dist\/node\/libnode.*\.dll$/i, /^package\/dist\/node\/libnode.*\.lib$/i],
   },

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ npm install @kungfu-tech/libnode
 
 The main package resolves the matching platform package installed through npm
 optional dependencies, such as `@kungfu-tech/libnode-darwin-arm64`,
-`@kungfu-tech/libnode-linux-x64`, or `@kungfu-tech/libnode-win32-x64`.
+`@kungfu-tech/libnode-linux-x64`, `@kungfu-tech/libnode-linux-arm64`, or
+`@kungfu-tech/libnode-win32-x64`.
 
 ### Compile and Link
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ node -p "require('@kungfu-tech/libnode').include"
 ## Build with GitHub Actions
 
 The `Build` workflow runs through Kungfu Buildchain and builds the Node.js version pinned by `libnode.release.json` and `.gitmodules`. Each runner packages its native output as an npm platform tarball under `build/stage/npm`.
+Linux ARM64 is built on the native GitHub-hosted `ubuntu-24.04-arm` runner and
+participates in the same source lock, artifact summary, and release passport as
+the other supported platforms.
 
 Npm publication is handled by Buildchain release-candidate promotion. Reviewed
 channel PRs build the release candidate once and upload the platform package

--- a/libnode.release.json
+++ b/libnode.release.json
@@ -3,6 +3,6 @@
   "nodeVersion": "22.22.3",
   "nodeTag": "v22.22.3",
   "nodeCommit": "fdfa0ff0dbaf0fbf4d7d6d89a2ab807f3177fa5c",
-  "libnodeRevision": 3,
-  "npmVersion": "22.22.3-kf.3-alpha.22"
+  "libnodeRevision": 5,
+  "npmVersion": "22.22.3-kf.5-alpha.1"
 }

--- a/libnode.release.json
+++ b/libnode.release.json
@@ -4,5 +4,5 @@
   "nodeTag": "v22.22.3",
   "nodeCommit": "fdfa0ff0dbaf0fbf4d7d6d89a2ab807f3177fa5c",
   "libnodeRevision": 3,
-  "npmVersion": "22.22.3-kf.3-alpha.21"
+  "npmVersion": "22.22.3-kf.3-alpha.22"
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "name": "kungfu-trader",
     "email": "info@kungfu.link"
   },
-  "version": "22.22.3-kf.3-alpha.21",
+  "version": "22.22.3-kf.3-alpha.22",
   "description": "Build shared node lib",
   "license": "Apache-2.0",
   "main": "src/js/index.js",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "name": "kungfu-trader",
     "email": "info@kungfu.link"
   },
-  "version": "22.22.3-kf.3-alpha.22",
+  "version": "22.22.3-kf.5-alpha.1",
   "description": "Build shared node lib",
   "license": "Apache-2.0",
   "main": "src/js/index.js",


### PR DESCRIPTION
## Summary

- add the native `@kungfu-tech/libnode-linux-arm64` platform package
- build it on GitHub's native `ubuntu-24.04-arm` runner
- require the fourth platform artifact in release promotion and KFD evidence
- advance the immutable package set to `22.22.3-kf.5-alpha.1` after the existing `kf.4` stable release

## Verification

- `corepack pnpm verify-release`
- `corepack pnpm verify-kfd-witnesses`
- `corepack pnpm verify-package-source`
- `actionlint .github/workflows/build.yml .github/workflows/release-verify.yaml .github/workflows/release-new-version.yml`
- `git diff --check`

The PR build is the native four-platform qualification, including Linux ARM64.