### PR TITLE
fix(ci): grant release promotion action writes

### DIFF
--- a/.buildchain/kfd-1/libnode-contract-world.witness.json
+++ b/.buildchain/kfd-1/libnode-contract-world.witness.json
@@ -81,9 +81,9 @@
     {
       "name": "release-workflow",
       "sourcePath": ".github/workflows/release-new-version.yml",
-      "sourceSha256": "91b87a6248668d93498af626d038df5925363d31393518c01ddbfdf5ae83ff4d",
+      "sourceSha256": "d00dff5ab631cdb4366499def10b62689a12666fb848d41b3a02ceb890b78ad4",
       "artifactPath": ".github/workflows/release-new-version.yml",
-      "expectedSha256": "91b87a6248668d93498af626d038df5925363d31393518c01ddbfdf5ae83ff4d",
+      "expectedSha256": "d00dff5ab631cdb4366499def10b62689a12666fb848d41b3a02ceb890b78ad4",
       "byteForByte": true
     },
     {

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  actions: read
+  actions: write
   checks: write
   contents: write
   id-token: write


### PR DESCRIPTION
## Summary

Grant the exact Actions permission required by the current Buildchain reusable release-promotion interface.

## Evidence

- alpha package candidate PR #127 passed the full four-platform build and merged normally
- push run 30155542605 failed before job startup because the called workflow requests `actions: write` while this caller granted only `actions: read`
- no npm package was partially published
- the patch changes only the caller workflow permission and passes actionlint

## Publication boundary

The follow-up alpha merge will reuse its protected PR candidate and OIDC trusted publisher. No branch protection or npm token bypass is requested.