### PR TITLE
fix(ci): grant release promotion pull request writes

### DIFF
--- a/.buildchain/kfd-1/libnode-contract-world.witness.json
+++ b/.buildchain/kfd-1/libnode-contract-world.witness.json
@@ -81,9 +81,9 @@
     {
       "name": "release-workflow",
       "sourcePath": ".github/workflows/release-new-version.yml",
-      "sourceSha256": "d00dff5ab631cdb4366499def10b62689a12666fb848d41b3a02ceb890b78ad4",
+      "sourceSha256": "1a3058306794928787e2c3408743a57f0f81355e3378b2ad0dbb85d031495904",
       "artifactPath": ".github/workflows/release-new-version.yml",
-      "expectedSha256": "d00dff5ab631cdb4366499def10b62689a12666fb848d41b3a02ceb890b78ad4",
+      "expectedSha256": "1a3058306794928787e2c3408743a57f0f81355e3378b2ad0dbb85d031495904",
       "byteForByte": true
     },
     {

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -13,6 +13,7 @@ permissions:
   contents: write
   id-token: write
   issues: write
+  pull-requests: write
 
 concurrency:
   group: libnode-release-new-version-${{ github.ref }}


### PR DESCRIPTION
## Summary

- grant the reusable release-promotion workflow the `pull-requests: write` permission required by the current `buildchain@v2-alpha` contract
- refresh the exact KFD-1 release-workflow witness
- retain protected alpha promotion with full native four-platform verification

## Evidence

- release run `30160579028` failed at workflow startup after PR #128 added `actions: write`
- the current reusable workflow interface also requires `pull-requests: write`
- `corepack pnpm verify-kfd-witnesses` passes
- `actionlint .github/workflows/release-new-version.yml` passes