### PR TITLE
build: upgrade Buildchain workflows to v3

### DIFF
--- a/.buildchain/kfd-1/libnode-contract-world.witness.json
+++ b/.buildchain/kfd-1/libnode-contract-world.witness.json
@@ -81,9 +81,9 @@
     {
       "name": "release-workflow",
       "sourcePath": ".github/workflows/release-new-version.yml",
-      "sourceSha256": "91b87a6248668d93498af626d038df5925363d31393518c01ddbfdf5ae83ff4d",
+      "sourceSha256": "72c8a803a139b53cdf065636737e023b564bc3d228ec97ef90f18551846e8f83",
       "artifactPath": ".github/workflows/release-new-version.yml",
-      "expectedSha256": "91b87a6248668d93498af626d038df5925363d31393518c01ddbfdf5ae83ff4d",
+      "expectedSha256": "72c8a803a139b53cdf065636737e023b564bc3d228ec97ef90f18551846e8f83",
       "byteForByte": true
     },
     {

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   build-matrix:
-    uses: kungfu-systems/buildchain/.github/workflows/build.yml@v2
+    uses: kungfu-systems/buildchain/.github/workflows/build.yml@v3
     with:
       runner-preset: custom
       platforms-json: >-

--- a/.github/workflows/buildchain-preflight.yml
+++ b/.github/workflows/buildchain-preflight.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v7.0.0
 
       - name: Validate Buildchain config
-        uses: kungfu-systems/buildchain/actions/validate-config@v2
+        uses: kungfu-systems/buildchain/actions/validate-config@v3
         with:
           config-required: 'true'
           require-version-state: 'true'

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   promote:
-    uses: kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@v2-alpha
+    uses: kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@v3-alpha
     secrets: inherit
     with:
       package-manager: pnpm

--- a/.github/workflows/release-verify.yaml
+++ b/.github/workflows/release-verify.yaml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   build:
-    uses: kungfu-systems/buildchain/.github/workflows/build.yml@v2
+    uses: kungfu-systems/buildchain/.github/workflows/build.yml@v3
     with:
       runner-preset: custom
       platforms-json: >-

--- a/buildchain.alpha-contract-lock.json
+++ b/buildchain.alpha-contract-lock.json
@@ -2,14 +2,14 @@
   "schemaVersion": 1,
   "contract": "kungfu-buildchain-contract-lock",
   "buildchain": {
-    "ref": "v2-alpha",
-    "resolvedSha": "9324835dcdd6e7611fe268c6551ffd4ef8284161",
+    "ref": "v3-alpha",
+    "resolvedSha": "658f93fa8667a47555246c016cf0b5ec0f5ec53d",
     "contract": "kungfu-buildchain-runtime-contract-world",
-    "contractDigest": "sha256:283d92cc0cf02ba5a6d179cb3d1c7599732e41722b93f81ee02b7962f5b2f137",
-    "compatibilityDigest": "sha256:edc3653e5cb34efd97065a6941db16140bbf375a565bbcf329d9d795bb07676f",
-    "majorLine": "v2",
+    "contractDigest": "sha256:956fb4092387d065d20db30ec0c03e6f7575acf7c40a9304dec2b77706b54d16",
+    "compatibilityDigest": "sha256:008b1c5a90a787cf30106829ac7aca68ab501f6d9c375e415d9c5c6b89039f46",
+    "majorLine": "v3",
     "compatibilityPolicy": "major-compatible",
-    "acceptedAt": "2026-07-20T21:35:41.000Z",
+    "acceptedAt": "2026-07-26T04:20:00.000Z",
     "surfaces": [
       {
         "id": "reusable-build",
@@ -24,7 +24,7 @@
       {
         "id": "release-candidate-promote",
         "kind": "workflow",
-        "breakingDigest": "sha256:1f476fb9a4854b362c4b24cef89a3c7675d7d63baf3bc828d7b8ae7d2787cead"
+        "breakingDigest": "sha256:acd401cfc46450115a3763fd4b679d85f185e8757ebd52510d6262e1533df4cf"
       },
       {
         "id": "advanced-release-candidate-promote",
@@ -37,9 +37,19 @@
         "breakingDigest": "sha256:da569f90374e878948e3d5160ed9929338ce0572473ca8ee54867b0fe1aaeace"
       },
       {
+        "id": "auditable-demo",
+        "kind": "workflow",
+        "breakingDigest": "sha256:a68f34d3dc24e0e0cd0040f978c174b62bf29a0472cebe1c43751e62408e6af6"
+      },
+      {
         "id": "promote-buildchain-ref-action",
         "kind": "action",
-        "breakingDigest": "sha256:a59f0910e6df842e7699139472e5dd69ac2fdd7f7213bf2cb346d1d622556874"
+        "breakingDigest": "sha256:6147c0a8d5c36bfaa6021871574e1fc28192a3f1b8cfdae4d24ef3059ac1ebda"
+      },
+      {
+        "id": "macos-credential-island-action",
+        "kind": "action",
+        "breakingDigest": "sha256:61866985864205770c70cbe14c3c60f479512a32c0b007b5fd6d8d65132ff8be"
       },
       {
         "id": "report-buildchain-issue-action",
@@ -99,7 +109,7 @@
       {
         "id": "controller:build-lifecycle",
         "kind": "controller",
-        "breakingDigest": "sha256:e264a79f9f399038c2fcfd21e4168c68c2e1485ee5c651c02242a02b622ac2be"
+        "breakingDigest": "sha256:30745921541e9b0f70475bb2178c2559f6aef248f6680670ccd44d8c5a69a6b1"
       },
       {
         "id": "controller:build-channel-router",
@@ -135,6 +145,11 @@
         "id": "controller:release-propagation",
         "kind": "controller",
         "breakingDigest": "sha256:d7a1f15990ce8bd13149474888232c7d4451dd2a49bebf4d4ce1336695da430e"
+      },
+      {
+        "id": "controller:binary-distribution",
+        "kind": "controller",
+        "breakingDigest": "sha256:7c18fdd3df180db9e1f043a2286ef3f02fae60b84e42b76cd50da9cfeb77883d"
       }
     ]
   }

--- a/buildchain.contract-lock.json
+++ b/buildchain.contract-lock.json
@@ -2,14 +2,14 @@
   "schemaVersion": 1,
   "contract": "kungfu-buildchain-contract-lock",
   "buildchain": {
-    "ref": "v2",
-    "resolvedSha": "3f7a5e4c82141dbd8568f3adc15e5bca3e5ec402",
+    "ref": "v3",
+    "resolvedSha": "9e904de2c85dbea7c799780ee166510b3336d812",
     "contract": "kungfu-buildchain-runtime-contract-world",
-    "contractDigest": "sha256:fa31f0a0692c23c6d7fb2bc605e0b6bfdb40e3b28f63b2f85f0f63cebaec42c9",
-    "compatibilityDigest": "sha256:edc3653e5cb34efd97065a6941db16140bbf375a565bbcf329d9d795bb07676f",
-    "majorLine": "v2",
+    "contractDigest": "sha256:914720131f07664cd187a1033f357c4952ef1008f5553cb6b285a75f786a7fbc",
+    "compatibilityDigest": "sha256:199fd83a7da33b0f654692ca973b33155e376ed50f0ce1f5864e1b6b18e0500a",
+    "majorLine": "v3",
     "compatibilityPolicy": "major-compatible",
-    "acceptedAt": "2026-07-20T21:55:19.000Z",
+    "acceptedAt": "2026-07-26T04:20:00.000Z",
     "surfaces": [
       {
         "id": "reusable-build",
@@ -24,7 +24,7 @@
       {
         "id": "release-candidate-promote",
         "kind": "workflow",
-        "breakingDigest": "sha256:1f476fb9a4854b362c4b24cef89a3c7675d7d63baf3bc828d7b8ae7d2787cead"
+        "breakingDigest": "sha256:acd401cfc46450115a3763fd4b679d85f185e8757ebd52510d6262e1533df4cf"
       },
       {
         "id": "advanced-release-candidate-promote",
@@ -39,7 +39,12 @@
       {
         "id": "promote-buildchain-ref-action",
         "kind": "action",
-        "breakingDigest": "sha256:a59f0910e6df842e7699139472e5dd69ac2fdd7f7213bf2cb346d1d622556874"
+        "breakingDigest": "sha256:6147c0a8d5c36bfaa6021871574e1fc28192a3f1b8cfdae4d24ef3059ac1ebda"
+      },
+      {
+        "id": "macos-credential-island-action",
+        "kind": "action",
+        "breakingDigest": "sha256:61866985864205770c70cbe14c3c60f479512a32c0b007b5fd6d8d65132ff8be"
       },
       {
         "id": "report-buildchain-issue-action",
@@ -99,7 +104,7 @@
       {
         "id": "controller:build-lifecycle",
         "kind": "controller",
-        "breakingDigest": "sha256:e264a79f9f399038c2fcfd21e4168c68c2e1485ee5c651c02242a02b622ac2be"
+        "breakingDigest": "sha256:30745921541e9b0f70475bb2178c2559f6aef248f6680670ccd44d8c5a69a6b1"
       },
       {
         "id": "controller:build-channel-router",
@@ -135,6 +140,11 @@
         "id": "controller:release-propagation",
         "kind": "controller",
         "breakingDigest": "sha256:d7a1f15990ce8bd13149474888232c7d4451dd2a49bebf4d4ce1336695da430e"
+      },
+      {
+        "id": "controller:binary-distribution",
+        "kind": "controller",
+        "breakingDigest": "sha256:7c18fdd3df180db9e1f043a2286ef3f02fae60b84e42b76cd50da9cfeb77883d"
       }
     ]
   }

--- a/docs/buildchain.md
+++ b/docs/buildchain.md
@@ -1,6 +1,6 @@
 # Buildchain Release Notes
 
-`libnode` uses Buildchain v2 for shared Kungfu GitHub Actions and for
+`libnode` uses Buildchain v3 for shared Kungfu GitHub Actions and for
 repository-local lifecycle metadata.
 
 ## Version State
@@ -10,7 +10,7 @@ For this repository the package version follows the upstream Node.js version
 that the embedded `node` submodule builds, plus a libnode package revision, for
 example `22.22.3-kf.0`.
 
-This repository uses Buildchain v2 anchored/manual version semantics:
+This repository uses Buildchain v3 anchored/manual version semantics:
 
 - `package.json#version` remains the npm package version.
 - `libnode.release.json` is the anchor manifest for the upstream Node.js tag,
@@ -49,7 +49,7 @@ packages release-oriented while allowing diagnostics runs to opt out with
 ## No-build Preflight
 
 The migration can be validated before running the expensive native build. The
-published Buildchain v2 `validate-config` action checks that
+published Buildchain v3 `validate-config` action checks that
 `buildchain.toml` is present, that `package.json#version` is readable as version
 state, that `libnode.release.json` is present as the anchor manifest, and that
 the required `install`, `build`, and `verify` lifecycle stages are declared.
@@ -62,7 +62,7 @@ The repository runs this check through
 and release lines:
 
 ```yaml
-uses: kungfu-systems/buildchain/actions/validate-config@v2
+uses: kungfu-systems/buildchain/actions/validate-config@v3
 with:
   config-required: 'true'
   require-version-state: 'true'
@@ -95,7 +95,7 @@ Actual npm publication is driven by reviewed Buildchain channel promotion, not
 by ad hoc publish branches. A pull request into `alpha/vN/vN.M` or
 `release/vN/vN.M` builds the native matrix once and uploads a
 release-candidate passport. After that PR is merged, the release workflow uses
-Buildchain `release-candidate-promote.yml@v2` to validate the PR-stage passport,
+Buildchain `release-candidate-promote.yml@v3` to validate the PR-stage passport,
 lock the corresponding `publish-gate/*` source ref, and publish without a second
 native rebuild. A merge into `alpha/vN/vN.M` publishes the package set with npm
 dist-tag `alpha`. A merge into `release/vN/vN.M` publishes the final package set
@@ -107,10 +107,10 @@ release/v22/v22.22
 ```
 
 The `Release - New Version` workflow calls Buildchain
-`release-candidate-promote.yml@v2` against the merged channel branch tip. The
+`release-candidate-promote.yml@v3` against the merged channel branch tip. The
 wrapper resolves the matching same-repository PR-stage `Build` run, downloads
 its release-candidate passport and npm tarballs, verifies source/tree
-equivalence, locks `publish-gate/*`, and then calls `promote-buildchain-ref@v2`
+equivalence, locks `publish-gate/*`, and then calls `promote-buildchain-ref@v3`
 with `publish-transaction: true`. Npm publication and Buildchain ref/tag
 promotion are one transaction with durable `buildchain/release-state/<version>`
 state and `BUILDCHAIN_PUBLISH_EVIDENCE`.


### PR DESCRIPTION
## Summary

- move Buildchain reusable workflows and validation actions from v2 to v3
- refresh stable and alpha contract locks
- refresh the KFD witness and Buildchain release documentation

## Validation

- frozen pnpm install
- Buildchain 3.0.0 config validation
- release contract verification
- KFD witness verification
- package source verification
- git diff check