### PR TITLE
docs(governance): require distinct protected review identities

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,5 @@
 # GitHub review and governance authority.
+# Protected content pushes and CODEOWNER approvals must use distinct identities.
 * @kungfu-origin
 
 # Last-match rules make authority and publication control surfaces explicit.


### PR DESCRIPTION
## Summary

- document that protected content pushes and CODEOWNER approvals use distinct identities
- create a real reviewable push by `dongkeren` so the existing last-push approval rule can be satisfied without self-review
- leave every CODEOWNERS pattern and owner unchanged

## Validation

- one comment-only line changed
- DCO sign-off enforced locally
- protected four-platform build remains required
- no administrator bypass or protection-rule mutation