### PR TITLE
fix(release): reconcile Alpha permissions with Buildchain v3

### DIFF
--- a/.buildchain/kfd-1/libnode-contract-world.witness.json
+++ b/.buildchain/kfd-1/libnode-contract-world.witness.json
@@ -81,9 +81,9 @@
     {
       "name": "release-workflow",
       "sourcePath": ".github/workflows/release-new-version.yml",
-      "sourceSha256": "d00dff5ab631cdb4366499def10b62689a12666fb848d41b3a02ceb890b78ad4",
+      "sourceSha256": "1a3058306794928787e2c3408743a57f0f81355e3378b2ad0dbb85d031495904",
       "artifactPath": ".github/workflows/release-new-version.yml",
-      "expectedSha256": "d00dff5ab631cdb4366499def10b62689a12666fb848d41b3a02ceb890b78ad4",
+      "expectedSha256": "1a3058306794928787e2c3408743a57f0f81355e3378b2ad0dbb85d031495904",
       "byteForByte": true
     },
     {

--- a/.buildchain/kfd-1/libnode-contract-world.witness.json
+++ b/.buildchain/kfd-1/libnode-contract-world.witness.json
@@ -81,9 +81,9 @@
     {
       "name": "release-workflow",
       "sourcePath": ".github/workflows/release-new-version.yml",
-      "sourceSha256": "91b87a6248668d93498af626d038df5925363d31393518c01ddbfdf5ae83ff4d",
+      "sourceSha256": "d00dff5ab631cdb4366499def10b62689a12666fb848d41b3a02ceb890b78ad4",
       "artifactPath": ".github/workflows/release-new-version.yml",
-      "expectedSha256": "91b87a6248668d93498af626d038df5925363d31393518c01ddbfdf5ae83ff4d",
+      "expectedSha256": "d00dff5ab631cdb4366499def10b62689a12666fb848d41b3a02ceb890b78ad4",
       "byteForByte": true
     },
     {

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,5 @@
 # GitHub review and governance authority.
+# Protected content pushes and CODEOWNER approvals must use distinct identities.
 * @kungfu-origin
 
 # Last-match rules make authority and publication control surfaces explicit.

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  actions: read
+  actions: write
   checks: write
   contents: write
   id-token: write

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -13,6 +13,7 @@ permissions:
   contents: write
   id-token: write
   issues: write
+  pull-requests: write
 
 concurrency:
   group: libnode-release-new-version-${{ github.ref }}


### PR DESCRIPTION
## Summary

- merge the reviewed Alpha publication fixes onto the current dev Buildchain v3 baseline
- retain `v3-alpha`, `actions: write`, and `pull-requests: write` together
- regenerate the exact KFD-1 workflow witness
- retain the distinct protected-pusher/CODEOWNER guidance

## Validation

- `node .gyp/libnode-kfd-witnesses.js check`
- `node .gyp/libnode-release-verify.js`
- `git diff --check`
- KFD3 artifact verifier requires the CI-built release tarball and is delegated to protected build

No administrator bypass or branch-protection mutation.