### PR TITLE
fix(runtime): promote Linux ARM64 resolver alpha

### DIFF
--- a/.buildchain/kfd-1/libnode-contract-world.witness.json
+++ b/.buildchain/kfd-1/libnode-contract-world.witness.json
@@ -10,12 +10,12 @@
   "contractWorld": {
     "id": "libnode-release-contract",
     "schemaId": "https://kfd.libkungfu.dev/schemas/kfd-1/contract-world.schema.json",
-    "digest": "sha256:c29741c757402b17ff91b026899c8ba91a9a4d9f58ccf817848b4cf7ef7d7bcf"
+    "digest": "sha256:492be91c6339c74bb6c661fed99e2f4001e78404fe565563ec2f2c8fe35978e0"
   },
   "standardContract": {
     "id": "libnode-release-contract",
     "path": "libnode.release.json",
-    "sha256": "c29741c757402b17ff91b026899c8ba91a9a4d9f58ccf817848b4cf7ef7d7bcf"
+    "sha256": "492be91c6339c74bb6c661fed99e2f4001e78404fe565563ec2f2c8fe35978e0"
   },
   "selfHostingBoundary": {
     "mode": "self-hosted-standard-contract",
@@ -33,17 +33,17 @@
     {
       "name": "package-manifest",
       "sourcePath": "package.json",
-      "sourceSha256": "835c764e2412cbe214ec992ebcecbd0e5649adce373e8a14b8374084646387ab",
+      "sourceSha256": "a95739be4b595e4c96f385afb6f039e149c872ecc18eafa7636a81eace773e1d",
       "artifactPath": "package.json",
-      "expectedSha256": "835c764e2412cbe214ec992ebcecbd0e5649adce373e8a14b8374084646387ab",
+      "expectedSha256": "a95739be4b595e4c96f385afb6f039e149c872ecc18eafa7636a81eace773e1d",
       "byteForByte": true
     },
     {
       "name": "release-manifest",
       "sourcePath": "libnode.release.json",
-      "sourceSha256": "c29741c757402b17ff91b026899c8ba91a9a4d9f58ccf817848b4cf7ef7d7bcf",
+      "sourceSha256": "492be91c6339c74bb6c661fed99e2f4001e78404fe565563ec2f2c8fe35978e0",
       "artifactPath": "libnode.release.json",
-      "expectedSha256": "c29741c757402b17ff91b026899c8ba91a9a4d9f58ccf817848b4cf7ef7d7bcf",
+      "expectedSha256": "492be91c6339c74bb6c661fed99e2f4001e78404fe565563ec2f2c8fe35978e0",
       "byteForByte": true
     },
     {
@@ -97,9 +97,9 @@
     {
       "name": "kfd3-prebuild-witness",
       "sourcePath": ".buildchain/kfd-3/collaboration-interface.prebuild.json",
-      "sourceSha256": "c7ae8d49e97e9b99c7393dbec05c63f0a038f20d76928a7b170e5b6d0fee1626",
+      "sourceSha256": "2feac3dd0e9b1ad19de8cc889c470c214229c71346baf49273a4c9f4ba0831f1",
       "artifactPath": ".buildchain/kfd-3/collaboration-interface.prebuild.json",
-      "expectedSha256": "c7ae8d49e97e9b99c7393dbec05c63f0a038f20d76928a7b170e5b6d0fee1626",
+      "expectedSha256": "2feac3dd0e9b1ad19de8cc889c470c214229c71346baf49273a4c9f4ba0831f1",
       "byteForByte": true
     }
   ]

--- a/.buildchain/kfd-1/libnode-contract-world.witness.json
+++ b/.buildchain/kfd-1/libnode-contract-world.witness.json
@@ -49,9 +49,9 @@
     {
       "name": "buildchain-config",
       "sourcePath": "buildchain.toml",
-      "sourceSha256": "cbac4d504308285a41dd04482b8aab18238481e641c74d1f3c0f47b6652a9ef7",
+      "sourceSha256": "136f62bda0b88a084878b67821940ed2d1f5c124096d2a7bf75b114362db3eb9",
       "artifactPath": "buildchain.toml",
-      "expectedSha256": "cbac4d504308285a41dd04482b8aab18238481e641c74d1f3c0f47b6652a9ef7",
+      "expectedSha256": "136f62bda0b88a084878b67821940ed2d1f5c124096d2a7bf75b114362db3eb9",
       "byteForByte": true
     },
     {

--- a/.buildchain/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd-3/collaboration-interface.prebuild.json
@@ -11,7 +11,7 @@
   "sourceRegistry": {
     "id": "libnode-release-contract",
     "path": "libnode.release.json",
-    "version": "22.22.3-kf.5-alpha.1"
+    "version": "22.22.3-kf.5-alpha.2"
   },
   "collaborationInterfaceDigest": "sha256:bbdfc87c532fe50fca92ca8415fc624af95c79fa7c9a4825efcee233701bd8c8",
   "collaborationInterface": {

--- a/.gyp/libnode-entrypoint.test.js
+++ b/.gyp/libnode-entrypoint.test.js
@@ -1,0 +1,38 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const entrypointPath = path.resolve(__dirname, '..', 'src', 'js', 'index.js');
+const entrypointSource = fs.readFileSync(entrypointPath, 'utf8');
+
+function loadEntrypoint(platform, arch) {
+  const exports = {};
+  const loadedPackages = [];
+  const sandbox = {
+    __dirname: path.dirname(entrypointPath),
+    exports,
+    process: { platform, arch },
+    require(packageName) {
+      if (packageName === 'path') return path;
+      if (packageName === 'fs') return { existsSync: () => false };
+      loadedPackages.push(packageName);
+      return {
+        include: `/packages/${packageName}/include`,
+        libpath: `/packages/${packageName}/lib`,
+      };
+    },
+  };
+
+  vm.runInNewContext(entrypointSource, sandbox, { filename: entrypointPath });
+  return { exports, loadedPackages };
+}
+
+test('Linux ARM64 resolves the published platform package', () => {
+  const loaded = loadEntrypoint('linux', 'arm64');
+
+  assert.deepEqual(loaded.loadedPackages, ['@kungfu-tech/libnode-linux-arm64']);
+  assert.equal(loaded.exports.platform, 'linux-arm64');
+  assert.equal(loaded.exports.platformPackageName, '@kungfu-tech/libnode-linux-arm64');
+});

--- a/buildchain.toml
+++ b/buildchain.toml
@@ -76,6 +76,7 @@ command = "corepack pnpm sync-kfd-witnesses"
 [lifecycle.verify]
 timeout_minutes = 10
 commands = [
+  "node --test .gyp/libnode-entrypoint.test.js",
   "corepack pnpm verify-release",
   "corepack pnpm verify-kfd-witnesses",
   "corepack pnpm verify-package-source",

--- a/libnode.release.json
+++ b/libnode.release.json
@@ -4,5 +4,5 @@
   "nodeTag": "v22.22.3",
   "nodeCommit": "fdfa0ff0dbaf0fbf4d7d6d89a2ab807f3177fa5c",
   "libnodeRevision": 5,
-  "npmVersion": "22.22.3-kf.5-alpha.1"
+  "npmVersion": "22.22.3-kf.5-alpha.2"
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "name": "kungfu-trader",
     "email": "info@kungfu.link"
   },
-  "version": "22.22.3-kf.5-alpha.1",
+  "version": "22.22.3-kf.5-alpha.2",
   "description": "Build shared node lib",
   "license": "Apache-2.0",
   "main": "src/js/index.js",

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -5,6 +5,7 @@ const rootDir = path.dirname(path.dirname(__dirname));
 const localDistDir = path.join(rootDir, 'dist', 'node');
 const platformPackageNames = {
   'darwin-arm64': '@kungfu-tech/libnode-darwin-arm64',
+  'linux-arm64': '@kungfu-tech/libnode-linux-arm64',
   'linux-x64': '@kungfu-tech/libnode-linux-x64',
   'win32-x64': '@kungfu-tech/libnode-win32-x64',
 };


### PR DESCRIPTION
## Summary

Promote the reviewed Linux ARM64 libnode resolver and immutable `22.22.3-kf.5-alpha.2` package set through the standard protected dev-to-alpha lineage.

## Evidence

- implementation PR: #141
- trusted exact-SHA four-platform run: `30229615444`
- Linux ARM64 job: success, 79m51s
- Linux ARM64 artifact: `libnode-linux-arm64-fc436b2c4f1c8fa6cc175f9d194af98185ad9a34` (44,273,485 bytes)
- implementation merge: `35e1a1fe7a36663247a2be1e58625ee296a7f9b8`

The alpha PR must build and publish the same four-platform package set through Buildchain trusted publishing.