### PR TITLE
ci: validate Buildchain KFD input train

### DIFF
--- a/.github/workflows/validate-buildchain-kfd-input-train.yml
+++ b/.github/workflows/validate-buildchain-kfd-input-train.yml
@@ -7,7 +7,12 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  actions: write
+  checks: write
+  contents: write
+  id-token: write
+  issues: write
+  pull-requests: write
 
 jobs:
   validate-contract:

--- a/.github/workflows/validate-buildchain-kfd-input-train.yml
+++ b/.github/workflows/validate-buildchain-kfd-input-train.yml
@@ -1,0 +1,13 @@
+name: Validate Buildchain KFD Input Train
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-contract:
+    if: ${{ false }}
+    uses: kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@train/v3/v3.0/kfd-passport-input-contract
+    secrets: inherit

--- a/.github/workflows/validate-buildchain-kfd-input-train.yml
+++ b/.github/workflows/validate-buildchain-kfd-input-train.yml
@@ -1,6 +1,9 @@
 name: Validate Buildchain KFD Input Train
 
 on:
+  pull_request:
+    branches:
+      - alpha/v22/v22.22
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Diagnostic-only PR for Buildchain train `train/v3/v3.0/kfd-passport-input-contract`. The only job is statically skipped; success proves GitHub can resolve and validate the full nested reusable-workflow contract without publishing artifacts or packages.

Related: kungfu-systems/buildchain#1951.