### PR TITLE
fix(release): promote attestation permissions to alpha

### DIFF
--- a/.buildchain/kfd-1/libnode-contract-world.witness.json
+++ b/.buildchain/kfd-1/libnode-contract-world.witness.json
@@ -81,9 +81,9 @@
     {
       "name": "release-workflow",
       "sourcePath": ".github/workflows/release-new-version.yml",
-      "sourceSha256": "5f537cfa14af83347ed910703c4aeb152954e00f7acc1d5f170107382081aed7",
+      "sourceSha256": "4034d36e9820d152eee70d4f7e34d08ce597893042206bde88443e2256d12212",
       "artifactPath": ".github/workflows/release-new-version.yml",
-      "expectedSha256": "5f537cfa14af83347ed910703c4aeb152954e00f7acc1d5f170107382081aed7",
+      "expectedSha256": "4034d36e9820d152eee70d4f7e34d08ce597893042206bde88443e2256d12212",
       "byteForByte": true
     },
     {

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -9,6 +9,8 @@ on:
 
 permissions:
   actions: write
+  artifact-metadata: write
+  attestations: write
   checks: write
   contents: write
   id-token: write


### PR DESCRIPTION
## Summary
- promote the reusable release attestation permission propagation to alpha
- retain the refreshed exact KFD workflow witness
- build the four-platform release-candidate set for `22.22.3-kf.5-alpha.2`

## Dev evidence
- #145 merged at `4516ff3a128e01845c81b346074f89e4131127bd`
- exact source head `8465b9d0b16f2c1462f804a50a59f12518ebf3c9` passed full Build run 30243358897 on Linux x64, Linux ARM64, macOS ARM64, and Windows x64