### PR TITLE
fix(release): promote attestation permissions to alpha

### DIFF
--- a/.buildchain/kfd-1/libnode-contract-world.witness.json
+++ b/.buildchain/kfd-1/libnode-contract-world.witness.json
@@ -81,9 +81,9 @@
     {
       "name": "release-workflow",
       "sourcePath": ".github/workflows/release-new-version.yml",
-      "sourceSha256": "5f537cfa14af83347ed910703c4aeb152954e00f7acc1d5f170107382081aed7",
+      "sourceSha256": "4034d36e9820d152eee70d4f7e34d08ce597893042206bde88443e2256d12212",
       "artifactPath": ".github/workflows/release-new-version.yml",
-      "expectedSha256": "5f537cfa14af83347ed910703c4aeb152954e00f7acc1d5f170107382081aed7",
+      "expectedSha256": "4034d36e9820d152eee70d4f7e34d08ce597893042206bde88443e2256d12212",
       "byteForByte": true
     },
     {

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -9,6 +9,8 @@ on:
 
 permissions:
   actions: write
+  artifact-metadata: write
+  attestations: write
   checks: write
   contents: write
   id-token: write


### PR DESCRIPTION
## Summary
- merge the validated dev release permission fix into alpha through an up-to-date promotion branch
- retain both protected branch histories without writing directly to dev or using admin bypass
- produce the exact four-platform release-candidate set for `22.22.3-kf.5-alpha.2`

## Evidence
- dev fix merged in #145 at `4516ff3a128e01845c81b346074f89e4131127bd`
- predecessor #146 run 30248380195 attempt 2 passed Linux x64, Linux ARM64, macOS ARM64, and Windows x64
- promotion merge commit is signed off and includes current alpha ancestry