### PR TITLE
chore(buildchain): accept alpha 7 contract

### DIFF
--- a/buildchain.alpha-contract-lock.json
+++ b/buildchain.alpha-contract-lock.json
@@ -3,13 +3,13 @@
   "contract": "kungfu-buildchain-contract-lock",
   "buildchain": {
     "ref": "v3-alpha",
-    "resolvedSha": "658f93fa8667a47555246c016cf0b5ec0f5ec53d",
+    "resolvedSha": "c83cb444d79c2e647de6e12a0bfde68dfaf57701",
     "contract": "kungfu-buildchain-runtime-contract-world",
-    "contractDigest": "sha256:956fb4092387d065d20db30ec0c03e6f7575acf7c40a9304dec2b77706b54d16",
+    "contractDigest": "sha256:a92b0189000ef05785d4c5097189e20856838adf94307c4174f36d5271616d16",
     "compatibilityDigest": "sha256:008b1c5a90a787cf30106829ac7aca68ab501f6d9c375e415d9c5c6b89039f46",
     "majorLine": "v3",
     "compatibilityPolicy": "major-compatible",
-    "acceptedAt": "2026-07-26T04:20:00.000Z",
+    "acceptedAt": "2026-07-27T12:10:18.000Z",
     "surfaces": [
       {
         "id": "reusable-build",


### PR DESCRIPTION
Summary:
- Accept the exact Buildchain v3.0.2-alpha.7 contract on the alpha lane.
- Preserve the existing major-compatible contract policy.

Verification:
- corepack pnpm verify-kfd-witnesses
- corepack pnpm verify-release
- git diff --check

This update establishes a fresh protected dev-to-alpha lineage for the corrected promotion workflow.