### PR TITLE
Promote libnode 22.22.3-kf.5-alpha.3 to Alpha

### DIFF
--- a/.buildchain/kfd-1/libnode-contract-world.witness.json
+++ b/.buildchain/kfd-1/libnode-contract-world.witness.json
@@ -97,9 +97,9 @@
     {
       "name": "kfd3-prebuild-witness",
       "sourcePath": ".buildchain/kfd-3/collaboration-interface.prebuild.json",
-      "sourceSha256": "2feac3dd0e9b1ad19de8cc889c470c214229c71346baf49273a4c9f4ba0831f1",
+      "sourceSha256": "2c597cda7a4ec550e684eaebfefd4dec8527864fb8b0ebcad5e0c70ccfe6e5ee",
       "artifactPath": ".buildchain/kfd-3/collaboration-interface.prebuild.json",
-      "expectedSha256": "2feac3dd0e9b1ad19de8cc889c470c214229c71346baf49273a4c9f4ba0831f1",
+      "expectedSha256": "2c597cda7a4ec550e684eaebfefd4dec8527864fb8b0ebcad5e0c70ccfe6e5ee",
       "byteForByte": true
     }
   ]

--- a/.buildchain/kfd-1/libnode-contract-world.witness.json
+++ b/.buildchain/kfd-1/libnode-contract-world.witness.json
@@ -10,12 +10,12 @@
   "contractWorld": {
     "id": "libnode-release-contract",
     "schemaId": "https://kfd.libkungfu.dev/schemas/kfd-1/contract-world.schema.json",
-    "digest": "sha256:492be91c6339c74bb6c661fed99e2f4001e78404fe565563ec2f2c8fe35978e0"
+    "digest": "sha256:30ba96a39aba6cd56222a785b4e9c0e9864ecf414d51a74ddfefee9c3ae8b1bc"
   },
   "standardContract": {
     "id": "libnode-release-contract",
     "path": "libnode.release.json",
-    "sha256": "492be91c6339c74bb6c661fed99e2f4001e78404fe565563ec2f2c8fe35978e0"
+    "sha256": "30ba96a39aba6cd56222a785b4e9c0e9864ecf414d51a74ddfefee9c3ae8b1bc"
   },
   "selfHostingBoundary": {
     "mode": "self-hosted-standard-contract",
@@ -33,25 +33,25 @@
     {
       "name": "package-manifest",
       "sourcePath": "package.json",
-      "sourceSha256": "a95739be4b595e4c96f385afb6f039e149c872ecc18eafa7636a81eace773e1d",
+      "sourceSha256": "de626755c62f2b3b252e0680b86e5dcddab7fdf8207ed76627e8c780d3210f56",
       "artifactPath": "package.json",
-      "expectedSha256": "a95739be4b595e4c96f385afb6f039e149c872ecc18eafa7636a81eace773e1d",
+      "expectedSha256": "de626755c62f2b3b252e0680b86e5dcddab7fdf8207ed76627e8c780d3210f56",
       "byteForByte": true
     },
     {
       "name": "release-manifest",
       "sourcePath": "libnode.release.json",
-      "sourceSha256": "492be91c6339c74bb6c661fed99e2f4001e78404fe565563ec2f2c8fe35978e0",
+      "sourceSha256": "30ba96a39aba6cd56222a785b4e9c0e9864ecf414d51a74ddfefee9c3ae8b1bc",
       "artifactPath": "libnode.release.json",
-      "expectedSha256": "492be91c6339c74bb6c661fed99e2f4001e78404fe565563ec2f2c8fe35978e0",
+      "expectedSha256": "30ba96a39aba6cd56222a785b4e9c0e9864ecf414d51a74ddfefee9c3ae8b1bc",
       "byteForByte": true
     },
     {
       "name": "buildchain-config",
       "sourcePath": "buildchain.toml",
-      "sourceSha256": "136f62bda0b88a084878b67821940ed2d1f5c124096d2a7bf75b114362db3eb9",
+      "sourceSha256": "3e9634b497b36eb78d3ea5eb0063fc49a98a32d6d34d34047aa5fe72e4de2f58",
       "artifactPath": "buildchain.toml",
-      "expectedSha256": "136f62bda0b88a084878b67821940ed2d1f5c124096d2a7bf75b114362db3eb9",
+      "expectedSha256": "3e9634b497b36eb78d3ea5eb0063fc49a98a32d6d34d34047aa5fe72e4de2f58",
       "byteForByte": true
     },
     {
@@ -97,9 +97,9 @@
     {
       "name": "kfd3-prebuild-witness",
       "sourcePath": ".buildchain/kfd-3/collaboration-interface.prebuild.json",
-      "sourceSha256": "2c597cda7a4ec550e684eaebfefd4dec8527864fb8b0ebcad5e0c70ccfe6e5ee",
+      "sourceSha256": "d9577384ae3690fadb3739635f88c209e456ca5eed69c2c2fe1fb3c76a47d0b5",
       "artifactPath": ".buildchain/kfd-3/collaboration-interface.prebuild.json",
-      "expectedSha256": "2c597cda7a4ec550e684eaebfefd4dec8527864fb8b0ebcad5e0c70ccfe6e5ee",
+      "expectedSha256": "d9577384ae3690fadb3739635f88c209e456ca5eed69c2c2fe1fb3c76a47d0b5",
       "byteForByte": true
     }
   ]

--- a/.buildchain/kfd-2/public-release-trust.claim.json
+++ b/.buildchain/kfd-2/public-release-trust.claim.json
@@ -1,7 +1,7 @@
 {
   "id": "claim:libnode-public-release-trust",
   "public": true,
-  "claim": "Libnode npm releases are anchored to libnode.release.json, built as a three-platform package set, verified by product-owned package gates, and published through Buildchain trusted publishing.",
+  "claim": "Libnode npm releases are anchored to libnode.release.json, built as a four-platform package set, verified by product-owned package gates, and published through Buildchain trusted publishing.",
   "sourceBindings": [
     {
       "id": "release-manifest",
@@ -56,6 +56,10 @@
     },
     {
       "name": "@kungfu-tech/libnode-linux-x64",
+      "kind": "npm-platform-package"
+    },
+    {
+      "name": "@kungfu-tech/libnode-linux-arm64",
       "kind": "npm-platform-package"
     },
     {

--- a/.buildchain/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd-3/collaboration-interface.prebuild.json
@@ -73,6 +73,16 @@
         "sourcePath": ".gyp/node-platform-package.js"
       },
       {
+        "id": "npm:platform-linux-arm64",
+        "name": "@kungfu-tech/libnode-linux-arm64 package",
+        "kind": "platform-package",
+        "availability": "shipped",
+        "visibility": "public",
+        "participantFacing": true,
+        "public": true,
+        "sourcePath": ".gyp/node-platform-package.js"
+      },
+      {
         "id": "npm:platform-win32-x64",
         "name": "@kungfu-tech/libnode-win32-x64 package",
         "kind": "platform-package",

--- a/.buildchain/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd-3/collaboration-interface.prebuild.json
@@ -11,7 +11,7 @@
   "sourceRegistry": {
     "id": "libnode-release-contract",
     "path": "libnode.release.json",
-    "version": "22.22.3-kf.5-alpha.2"
+    "version": "22.22.3-kf.5-alpha.3"
   },
   "collaborationInterfaceDigest": "sha256:bbdfc87c532fe50fca92ca8415fc624af95c79fa7c9a4825efcee233701bd8c8",
   "collaborationInterface": {

--- a/.gyp/libnode-kfd-release-evidence.test.js
+++ b/.gyp/libnode-kfd-release-evidence.test.js
@@ -1,0 +1,29 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const repoRoot = path.resolve(__dirname, '..');
+
+function readJson(relativePath) {
+  return JSON.parse(fs.readFileSync(path.join(repoRoot, relativePath), 'utf8'));
+}
+
+test('KFD-3 prebuild witness mirrors every authoritative public surface', () => {
+  const collaborationInterface = readJson('.buildchain/kfd-3/collaboration-interface.json');
+  const prebuild = readJson('.buildchain/kfd-3/collaboration-interface.prebuild.json');
+  const authoritativeSurfaceIds = collaborationInterface.surfaces.map(({ id }) => id);
+  const witnessedSurfaceIds = prebuild.collaborationInterface.surfaces.map(({ id }) => id);
+
+  assert.deepEqual(witnessedSurfaceIds, authoritativeSurfaceIds);
+  assert.ok(witnessedSurfaceIds.includes('npm:platform-linux-arm64'));
+  assert.equal(prebuild.collaborationInterface.digest, prebuild.collaborationInterfaceDigest);
+});
+
+test('KFD-2 public release claim covers the four-platform package set', () => {
+  const trustClaim = readJson('.buildchain/kfd-2/public-release-trust.claim.json');
+  const artifactNames = trustClaim.artifacts.map(({ name }) => name);
+
+  assert.match(trustClaim.claim, /four-platform package set/);
+  assert.ok(artifactNames.includes('@kungfu-tech/libnode-linux-arm64'));
+});

--- a/.gyp/libnode-kfd-witnesses.js
+++ b/.gyp/libnode-kfd-witnesses.js
@@ -62,6 +62,7 @@ function writeIfChanged(relativePath, text) {
 function generatedKfd3Prebuild() {
   const release = readJson(paths.release);
   const prebuild = readJson(paths.kfd3Prebuild);
+  const collaborationInterface = readJson(paths.kfd3Interface);
   const interfaceDigest = `sha256:${sha256File(paths.kfd3Interface)}`;
 
   prebuild.sourceRegistry = {
@@ -69,9 +70,15 @@ function generatedKfd3Prebuild() {
     version: release.npmVersion,
   };
   prebuild.collaborationInterfaceDigest = interfaceDigest;
-  if (prebuild.collaborationInterface && typeof prebuild.collaborationInterface === 'object') {
-    prebuild.collaborationInterface.digest = interfaceDigest;
-  }
+  prebuild.collaborationInterface = {
+    schemaVersion: collaborationInterface.schemaVersion,
+    contract: collaborationInterface.contract,
+    digest: interfaceDigest,
+    product: collaborationInterface.product,
+    participants: collaborationInterface.participants,
+    surfaces: collaborationInterface.surfaces,
+    closure: collaborationInterface.closure,
+  };
 
   return prebuild;
 }

--- a/buildchain.toml
+++ b/buildchain.toml
@@ -77,6 +77,7 @@ command = "corepack pnpm sync-kfd-witnesses"
 timeout_minutes = 10
 commands = [
   "node --test .gyp/libnode-entrypoint.test.js",
+  "node --test .gyp/libnode-kfd-release-evidence.test.js",
   "corepack pnpm verify-release",
   "corepack pnpm verify-kfd-witnesses",
   "corepack pnpm verify-package-source",

--- a/libnode.release.json
+++ b/libnode.release.json
@@ -4,5 +4,5 @@
   "nodeTag": "v22.22.3",
   "nodeCommit": "fdfa0ff0dbaf0fbf4d7d6d89a2ab807f3177fa5c",
   "libnodeRevision": 5,
-  "npmVersion": "22.22.3-kf.5-alpha.2"
+  "npmVersion": "22.22.3-kf.5-alpha.3"
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "name": "kungfu-trader",
     "email": "info@kungfu.link"
   },
-  "version": "22.22.3-kf.5-alpha.2",
+  "version": "22.22.3-kf.5-alpha.3",
   "description": "Build shared node lib",
   "license": "Apache-2.0",
   "main": "src/js/index.js",


### PR DESCRIPTION
## Summary
- promote exact qualified dev head `4fdf3bc0863706de1d900d4786d50a70fbd70091` to `alpha/v22/v22.22`
- carry the Linux ARM64 KFD-2/KFD-3 release-passport repair and regression coverage
- publish the immutable `22.22.3-kf.5-alpha.3` package set only after protected Alpha checks

## Qualification
- source PR #153 merged after independent review
- exact four-platform Build run: https://github.com/kungfu-systems/libnode/actions/runs/30294711727
- Linux x64, Linux ARM64, macOS ARM64, and Windows x64: success
- Buildchain controller evidence and aggregate `build`: success

This is the unique dev-to-Alpha release intent for the exact source head.