### PR TITLE
Allow cold Node source preparation

### DIFF
--- a/.buildchain/kfd-1/libnode-contract-world.witness.json
+++ b/.buildchain/kfd-1/libnode-contract-world.witness.json
@@ -49,9 +49,9 @@
     {
       "name": "buildchain-config",
       "sourcePath": "buildchain.toml",
-      "sourceSha256": "fbc596052c556a59812070ad5d5be093e51ba995cffa6e7b809eb60bbc8f54ae",
+      "sourceSha256": "66782a978e1914d076d81998a3678365ed7eedad407826ad0f7d8c2e69ad6c42",
       "artifactPath": "buildchain.toml",
-      "expectedSha256": "fbc596052c556a59812070ad5d5be093e51ba995cffa6e7b809eb60bbc8f54ae",
+      "expectedSha256": "66782a978e1914d076d81998a3678365ed7eedad407826ad0f7d8c2e69ad6c42",
       "byteForByte": true
     },
     {

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,7 @@ jobs:
       checkout-cache-mirror-url-template: ${{ vars.BUILDCHAIN_CHECKOUT_CACHE_MIRROR_URL_TEMPLATE }}
       checkout-cache-fallback: github
       checkout-cache-timeout-seconds: 60
+      lifecycle-timeout-minutes: 240
       setup-node: true
       node-version: '24'
       install-command: node .gyp/buildchain-install.js "${{ vars.KF_NODE_GIT_URL }}" "${{ vars.KF_NODE_REFERENCE }}"

--- a/.github/workflows/release-verify.yaml
+++ b/.github/workflows/release-verify.yaml
@@ -32,6 +32,7 @@ jobs:
       checkout-cache-mirror-url-template: ${{ vars.BUILDCHAIN_CHECKOUT_CACHE_MIRROR_URL_TEMPLATE }}
       checkout-cache-fallback: github
       checkout-cache-timeout-seconds: 60
+      lifecycle-timeout-minutes: 240
       setup-node: true
       node-version: '24'
       install-command: node .gyp/buildchain-install.js "${{ vars.KF_NODE_GIT_URL }}" "${{ vars.KF_NODE_REFERENCE }}"

--- a/buildchain.toml
+++ b/buildchain.toml
@@ -57,7 +57,10 @@ cache_dirs = [
 ]
 
 [lifecycle.install]
-timeout_minutes = 10
+# Preparing the pinned Node.js source can transfer more than 1 GiB on a cold
+# macOS x64 runner. Keep this stage bounded while allowing slow GitHub fetches
+# to finish before the native build begins.
+timeout_minutes = 45
 commands = [
   "corepack pnpm install --frozen-lockfile --ignore-scripts",
   "corepack pnpm prepare-node-source",


### PR DESCRIPTION
Raise the bounded libnode install lifecycle budget from 10 to 45 minutes. The protected Alpha promotion candidate showed macOS x64 fetching the pinned Node source beyond 600 MiB before the 10-minute stage timeout; the preceding five-platform build proved the native build itself succeeds. This keeps the stage bounded while allowing cold runners to finish source preparation.